### PR TITLE
Conditional sections based on A/B testing

### DIFF
--- a/src/defaults/html.pipe.js
+++ b/src/defaults/html.pipe.js
@@ -22,7 +22,7 @@ const type = require('../utils/set-content-type.js');
 const status = require('../html/set-status.js');
 const smartypants = require('../html/smartypants');
 const sections = require('../html/split-sections');
-const { selectstrain } = require('../utils/conditional-sections');
+const { selectstrain, selecttest } = require('../utils/conditional-sections');
 const debug = require('../html/output-debug.js');
 const { esi, flag } = require('../html/flag-esi');
 const key = require('../html/set-surrogate-key');
@@ -49,6 +49,7 @@ const htmlpipe = (cont, payload, action) => {
     .before(sections)
     .before(meta)
     .before(selectstrain)
+    .before(selecttest)
     .before(html)
     .before(responsive)
     .before(emit)


### PR DESCRIPTION
This is part II of #57 

By adding `test: groupname` to the front matter of multiple sections, the pipeline will randomly, but repeatably (using the strain name as random seed) pick exactly one section with that particular name of the test group and hide all others.