### PR TITLE
Fix a bug where single element markdowns would be discarded.

### DIFF
--- a/src/html/emit-html.js
+++ b/src/html/emit-html.js
@@ -12,13 +12,7 @@
 
 function emit({ content: { document } }, { logger }) {
   logger.debug(`Emitting HTML from ${typeof document}`);
-
-  const children = document.body && document.body.firstChild && document.body.firstChild.childNodes
-    ? Array.from(document.body.firstChild.childNodes)
-      .filter(node => node && node.outerHTML)
-      .map(node => node.outerHTML) : [];
-
-  return { content: { html: document.body.innerHTML || '', children } };
+  return { content: { html: document.body.firstChild.innerHTML || '', children } };
 }
 
 module.exports = emit;

--- a/src/utils/mdast-to-vdom.js
+++ b/src/utils/mdast-to-vdom.js
@@ -78,11 +78,7 @@ class VDOMTransformer {
   static toHTAST(htmlstr, cb, node) {
     // we parse the string to HTAST
     const htast = unified().use(parse, { fragment: true }).parse(htmlstr);
-    /* h(node, tagName, props, children) */
-    if (htast.children.length === 1) {
-      const child = htast.children[0];
-      return cb(node, child.tagName, child.properties, child.children);
-    }
+    // TODO: Get rid of the wrapper div
     return cb(node, 'div', {}, htast.children);
   }
 


### PR DESCRIPTION
Contains removal of the children property in the pipeline (#105). Is the work done to deprecate the property finished yet?