### PR TITLE
Fix problems in the markdown -> html pipeline

### DIFF
--- a/docs/content.schema.json
+++ b/docs/content.schema.json
@@ -49,14 +49,6 @@
             "description": "Deprecated: the Hypermedia (HAST) AST",
             "meta:status": "deprecated"
         },
-        "children": {
-            "type": "array",
-            "description": "Deprecated: the main HTML elements of the document. `document.children[].innerHTML` instead.",
-            "items": {
-                "type": "string"
-            },
-            "meta:status": "deprecated"
-        },
         "html": {
             "type": "string",
             "meta:status": "deprecated",

--- a/docs/content.schema.md
+++ b/docs/content.schema.md
@@ -22,7 +22,6 @@ The content as retrieved from the repository and enriched in the pipeline.
 | Property | Type | Required | Defined by |
 |----------|------|----------|------------|
 | [body](#body) | `string` | Optional | Content (this schema) |
-| [children](#children) | `string[]` | Optional | Content (this schema) |
 | [document](#document) | `object` | Optional | Content (this schema) |
 | [htast](#htast) | `object` | Optional | Content (this schema) |
 | [html](#html) | `string` | Optional | Content (this schema) |
@@ -48,32 +47,6 @@ The content body of the retrieved source document
 
 
 `string`
-
-
-
-
-
-
-## children
-
-Deprecated: the main HTML elements of the document. `document.children[].innerHTML` instead.
-
-`children`
-* is optional
-* type: `string[]`
-
-* defined in this schema
-
-### children Type
-
-
-Array type: `string[]`
-
-All items must be of the type:
-`string`
-
-
-
 
 
 

--- a/docs/mdast.schema.json
+++ b/docs/mdast.schema.json
@@ -138,7 +138,10 @@
             }
         },
         "lang": {
-            "type": "string",
+            "type": [
+                "null",
+                "string"
+            ],
             "description": "For code, a lang field can be present. It represents the language of computer code being marked up."
         },
         "meta": {

--- a/docs/mdast.schema.md
+++ b/docs/mdast.schema.md
@@ -27,7 +27,7 @@ A node in the Markdown AST
 | [depth](#depth) | `integer` | Optional | MDAST (this schema) |
 | [identifier](#identifier) | `string` | Optional | MDAST (this schema) |
 | [label](#label) | `string` | Optional | MDAST (this schema) |
-| [lang](#lang) | `string` | Optional | MDAST (this schema) |
+| [lang](#lang) | complex | Optional | MDAST (this schema) |
 | [meta](#meta) | complex | Optional | MDAST (this schema) |
 | [ordered](#ordered) | `boolean` | Optional | MDAST (this schema) |
 | [position](#position) | Position | Optional | MDAST (this schema) |
@@ -208,14 +208,23 @@ For code, a lang field can be present. It represents the language of computer co
 
 `lang`
 * is optional
-* type: `string`
+* type: complex
 * defined in this schema
 
 ### lang Type
 
+Unknown type `null,string`.
 
-`string`
-
+```json
+{
+  "type": [
+    "null",
+    "string"
+  ],
+  "description": "For code, a lang field can be present. It represents the language of computer code being marked up.",
+  "simpletype": "complex"
+}
+```
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,22 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@adobe/helix-shared": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared/-/helix-shared-0.6.0.tgz",
+      "integrity": "sha512-I+pXpW+irCwyAyy9Xzoxc0P+OxKLQBCuYEJZ8mUsrWfhz0RzS4FFf0XgIdsiu73peKGZhcQLLo95DC1PFa4HBw==",
+      "requires": {
+        "ajv": "6.6.2",
+        "fs-extra": "^7.0.0",
+        "object-hash": "^1.3.1",
+        "shelljs": "^0.8.2",
+        "triple-beam": "^1.3.0",
+        "uri-js": "^4.2.2",
+        "uuid": "^3.3.2",
+        "winston": "^3.1.0",
+        "yaml": "^1.2.1"
+      }
+    },
     "@adobe/jsonschema2md": {
       "version": "1.1.1-SNAPSHOT.236",
       "resolved": "https://registry.npmjs.org/@adobe/jsonschema2md/-/jsonschema2md-1.1.1-SNAPSHOT.236.tgz",
@@ -932,8 +948,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -1102,7 +1117,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1401,7 +1415,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -1545,8 +1559,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "configstore": {
       "version": "3.1.2",
@@ -1599,7 +1612,7 @@
     },
     "core-js": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
       "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU=",
       "dev": true
     },
@@ -2078,7 +2091,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
@@ -2666,7 +2679,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
@@ -2972,8 +2985,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "ftp": {
       "version": "0.3.10",
@@ -2987,7 +2999,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -3082,7 +3094,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3417,7 +3428,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -3554,7 +3565,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3592,6 +3602,11 @@
         "strip-ansi": "^4.0.0",
         "through": "^2.3.6"
       }
+    },
+    "interpret": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
     },
     "invariant": {
       "version": "2.2.4",
@@ -3775,7 +3790,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -4642,7 +4657,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -5059,6 +5073,7 @@
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -5425,7 +5440,8 @@
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -5536,6 +5552,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -5588,7 +5605,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -5891,7 +5909,8 @@
           "version": "1.6.1",
           "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",
@@ -6417,7 +6436,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -6487,7 +6505,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -6496,7 +6514,7 @@
     },
     "os-name": {
       "version": "2.0.1",
-      "resolved": "http://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
       "integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
       "dev": true,
       "requires": {
@@ -6657,8 +6675,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -6675,8 +6692,7 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -6993,6 +7009,14 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "recursive-readdir": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
@@ -7180,7 +7204,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-      "dev": true,
       "requires": {
         "path-parse": "^1.0.5"
       }
@@ -7450,7 +7473,7 @@
       "dependencies": {
         "kind-of": {
           "version": "2.0.1",
-          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "dev": true,
           "requires": {
@@ -7473,6 +7496,16 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -8044,7 +8077,7 @@
     },
     "string_decoder": {
       "version": "0.10.31",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
@@ -8945,7 +8978,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -8981,7 +9014,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -8993,8 +9026,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",
@@ -9095,6 +9127,11 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
+    "yaml": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.2.1.tgz",
+      "integrity": "sha512-LuOeoZc6LYguU9H/XCbrPfuDpCGJVf+o/r9uLCGnsHiHk/8Cr7IVeXOilO8yK0XA8QJPlX22KVofINt8xhdwqg=="
+    },
     "yargs": {
       "version": "3.32.0",
       "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
@@ -9138,7 +9175,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "unist-util-remove-position": "^1.1.2"
   },
   "dependencies": {
-    "@adobe/helix-shared": "0.3.0",
+    "@adobe/helix-shared": "0.6.0",
     "@adobe/openwhisk-loggly-wrapper": "0.4.1",
     "ajv": "^6.6.2",
     "callsites": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "unist-util-remove-position": "^1.1.2"
   },
   "dependencies": {
+    "@adobe/helix-shared": "0.3.0",
     "@adobe/openwhisk-loggly-wrapper": "0.4.1",
     "ajv": "^6.6.2",
     "callsites": "^3.0.0",

--- a/src/action.d.ts
+++ b/src/action.d.ts
@@ -105,6 +105,10 @@ export interface Secrets {
    */
   REPO_RAW_ROOT?: string;
   /**
+   * The base URL for all GitHub API operations
+   */
+  REPO_API_ROOT?: string;
+  /**
    * Comma-separated list of allowed hostnames for embeds. Supports `*.example.com` as a subdomain wildcard. Use `*` to allow all embeds (potentially insecure)
    */
   EMBED_WHITELIST?: string;
@@ -115,22 +119,31 @@ export interface Secrets {
   /**
    * Minimum physical width of responsive images to generate
    */
-  IMAGES_MIN_SIZE?: string;
+  IMAGES_MIN_SIZE?: number;
+  /**
+   * Timeout for outgoing HTTP requests in milliseconds
+   */
+  HTTP_TIMEOUT?: number;
   /**
    * Maximum physical with of responsive images to generate
    */
-  IMAGES_MAX_SIZE?: string;
+  IMAGES_MAX_SIZE?: number;
   /**
    * Number of intermediary size steps to create per image
    */
-  IMAGES_SIZE_STEPS?: string;
+  IMAGES_SIZE_STEPS?: number;
   /**
    * Value for the `sizes` attribute of generated responsive images
    */
   IMAGES_SIZES?: string;
+  TEST_BOOLEAN?: boolean;
+  /**
+   * Print XML with line breaks and indentation
+   */
+  XML_PRETTY?: boolean;
   /**
    * This interface was referenced by `Secrets`'s JSON-Schema definition
    * via the `patternProperty` "[A-Z0-9_]+".
    */
-  [k: string]: string;
+  [k: string]: boolean | number | string;
 }

--- a/src/context.d.ts
+++ b/src/context.d.ts
@@ -95,11 +95,7 @@ export interface Request {
    */
   url?: string;
   /**
-   * The resource path (without extension) that has been requested
-   */
-  resourcePath?: string;
-  /**
-   * The path and request parameters of the request URL
+   * The path of the request URL
    */
   path?: string;
   /**
@@ -111,7 +107,7 @@ export interface Request {
    */
   extension?: string;
   /**
-   * The HTTP method of the request
+   * The HTTP method of the request. Note: method names can be lower-case.
    */
   method?: string;
   /**
@@ -157,13 +153,15 @@ export interface Content {
     [k: string]: any;
   };
   /**
-   * Deprecated: the main HTML elements of the document. `document.children[].innerHTML` instead.
-   */
-  children?: string[];
-  /**
    * Deprecated: the main HTML of the document. Use `document.innerHTML` instead.
    */
   html?: string;
+  /**
+   * The XML object to emit. See xmlbuilder-js for syntax.
+   */
+  xml?: {
+    [k: string]: any;
+  };
   /**
    * Extracted metadata fron the frontmatter of the document
    */

--- a/src/context.d.ts
+++ b/src/context.d.ts
@@ -252,7 +252,7 @@ export interface MDAST {
   /**
    * For code, a lang field can be present. It represents the language of computer code being marked up.
    */
-  lang?: string;
+  lang?: null | string;
   /**
    * For code, if lang is present, a meta field can be present. It represents custom information relating to the node.
    */

--- a/src/defaults/html.pipe.js
+++ b/src/defaults/html.pipe.js
@@ -42,7 +42,7 @@ const htmlpipe = (cont, payload, action) => {
     .every(dump).when(() => !production())
     .every(validate).when(() => !production())
     .before(fetch)
-    .when(({ content }) => !(content && content.body && content.body.length > 0))
+    .when(({ content }) => !(content !== undefined && content.body !== undefined))
     .before(parse)
     .before(embeds)
     .before(smartypants)

--- a/src/html/emit-html.js
+++ b/src/html/emit-html.js
@@ -13,12 +13,9 @@
 function emit({ content: { document } }, { logger }) {
   logger.debug(`Emitting HTML from ${typeof document}`);
 
-  const children = document.body && document.body.firstChild && document.body.firstChild.childNodes
-    ? Array.from(document.body.firstChild.childNodes)
-      .filter(node => node && node.outerHTML)
-      .map(node => node.outerHTML) : [];
-
-  return { content: { html: document.body.innerHTML || '', children } };
+  const html = document.body.innerHTML || '';
+  const children = Array.from(document.body.childNodes).map(node => node.outerHTML).filter(x => x);
+  return { content: { html, children } };
 }
 
 module.exports = emit;

--- a/src/html/emit-html.js
+++ b/src/html/emit-html.js
@@ -12,10 +12,7 @@
 
 function emit({ content: { document } }, { logger }) {
   logger.debug(`Emitting HTML from ${typeof document}`);
-
-  const html = document.body.innerHTML || '';
-  const children = Array.from(document.body.childNodes).map(node => node.outerHTML).filter(x => x);
-  return { content: { html, children } };
+  return { content: { html: document.body.innerHTML || '' } };
 }
 
 module.exports = emit;

--- a/src/schemas/content.schema.json
+++ b/src/schemas/content.schema.json
@@ -49,14 +49,6 @@
       "description": "Deprecated: the Hypermedia (HAST) AST",
       "meta:status": "deprecated"
     },
-    "children": {
-      "type": "array",
-      "description": "Deprecated: the main HTML elements of the document. `document.children[].innerHTML` instead.",
-      "items": {
-        "type": "string"
-      },
-      "meta:status": "deprecated"
-    },
     "html": {
       "type": "string",
       "meta:status": "deprecated",

--- a/src/schemas/mdast.schema.json
+++ b/src/schemas/mdast.schema.json
@@ -124,7 +124,7 @@
       }
     },
     "lang": {
-      "type": "string",
+      "type": ["null", "string"],
       "description": "For code, a lang field can be present. It represents the language of computer code being marked up."
     },
     "meta": {

--- a/src/utils/mdast-to-vdom.js
+++ b/src/utils/mdast-to-vdom.js
@@ -13,11 +13,10 @@
 /* eslint no-unused-vars: ["error", { "argsIgnorePattern": "^_" }] */
 const { selectAll } = require('unist-util-select');
 const handlers = require('mdast-util-to-hast/lib/handlers');
-const tohast = require('mdast-util-to-hast');
+const mdast2hast = require('mdast-util-to-hast');
+const hast2html = require('hast-util-to-html');
 const unified = require('unified');
 const parse = require('rehype-parse');
-const tohyper = require('hast-to-hyperscript');
-const h = require('hyperscript');
 const { JSDOM } = require('jsdom');
 const image = require('./image-handler');
 const embed = require('./embed-handler');
@@ -189,20 +188,13 @@ class VDOMTransformer {
   }
 
   /**
-   * Turns the MDAST into a basic DOM-like structure using Hyperscript
-   * @returns {Node} a simple DOM node (not all DOM functions exposed)
-   */
-  process() {
-    // turn MDAST to HTAST and then HTAST to VDOM via Hyperscript
-    return tohyper(h, tohast(this._root, { handlers: this._handlers }));
-  }
-
-  /**
    * Turns the MDAST into a full DOM-like structure using JSDOM
    * @returns {Node} a full DOM node
    */
   getDocument() {
-    return new JSDOM(this.process().outerHTML).window.document;
+    // mdast -> hast; hast -> html -> DOM using JSDOM
+    const hast = mdast2hast(this._root, { handlers: this._handlers });
+    return new JSDOM(hast2html(hast)).window.document;
   }
 }
 

--- a/test/testEmbedHandler.js
+++ b/test/testEmbedHandler.js
@@ -118,9 +118,9 @@ https://www.youtube.com/watch?v=KOxbO0EI4MA
 
     assert.equal(result.response.status, 201);
     assert.equal(result.response.headers['Content-Type'], 'text/html');
-    assert.equal(result.response.body, `<div><p>Hello World
+    assert.equal(result.response.body, `<p>Hello World
 Here comes an embed.</p>
 <esi:include src="https://example-embed-service.com/https://www.youtube.com/watch?v=KOxbO0EI4MA"></esi:include>
-<p><img src="easy.png" alt="Easy!" srcset="easy.png?width=480&amp;auto=webp 480w,easy.png?width=1384&amp;auto=webp 1384w,easy.png?width=2288&amp;auto=webp 2288w,easy.png?width=3192&amp;auto=webp 3192w,easy.png?width=4096&amp;auto=webp 4096w" sizes="100vw"></p></div>`);
+<p><img src="easy.png" alt="Easy!" srcset="easy.png?width=480&amp;auto=webp 480w,easy.png?width=1384&amp;auto=webp 1384w,easy.png?width=2288&amp;auto=webp 2288w,easy.png?width=3192&amp;auto=webp 3192w,easy.png?width=4096&amp;auto=webp 4096w" sizes="100vw"></p>`);
   });
 });

--- a/test/testEmitHTML.js
+++ b/test/testEmitHTML.js
@@ -29,7 +29,6 @@ describe('Test HTML emitter', () => {
     assert.deepEqual(
       out, {
         content: {
-          children: [],
           html: '',
         },
       },
@@ -56,7 +55,6 @@ describe('Test HTML emitter', () => {
     assert.deepEqual(
       out, {
         content: {
-          children: ['a', 'b'],
           html: 'ab',
         },
       },

--- a/test/testHTMLFromMarkdown.js
+++ b/test/testHTMLFromMarkdown.js
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+const winston = require('winston');
+const { JSDOM } = require('jsdom');
+const { assertEquivalentNode } = require('@adobe/helix-shared').dom;
+const { pipe } = require('../src/defaults/html.pipe.js');
+
+const params = {
+  path: '/hello.md',
+  __ow_method: 'get',
+  owner: 'trieloff',
+  __ow_headers: {
+    'X-Forwarded-Port': '443',
+    'X-CDN-Request-Id': '2a208a89-e071-44cf-aee9-220880da4c1e',
+    'Fastly-Client': '1',
+    'X-Forwarded-Host': 'runtime.adobe.io',
+    'Upgrade-Insecure-Requests': '1',
+    Host: 'controller-a',
+    Connection: 'close',
+    'Fastly-SSL': '1',
+    'X-Request-Id': 'RUss5tPdgOfw74a68aNc24FeTipGpVfW',
+    'X-Branch': 'master',
+    'Accept-Language': 'en-US, en;q=0.9, de;q=0.8',
+    'X-Forwarded-Proto': 'https',
+    'Fastly-Orig-Accept-Encoding': 'gzip',
+    'X-Varnish': '267021320',
+    DNT: '1',
+    'X-Forwarded-For':
+      '192.147.117.11, 157.52.92.27, 23.235.46.33, 10.64.221.107',
+    'X-Host': 'www.primordialsoup.life',
+    Accept:
+      'text/html, application/xhtml+xml, application/xml;q=0.9, image/webp, image/apng, */*;q=0.8',
+    'X-Real-IP': '10.64.221.107',
+    'X-Forwarded-Server': 'cache-lcy19249-LCY, cache-iad2127-IAD',
+    'Fastly-Client-IP': '192.147.117.11',
+    'Perf-Br-Req-In': '1529585370.116',
+    'X-Timer': 'S1529585370.068237,VS0,VS0',
+    'Fastly-FF':
+      'dc/x3e9z8KMmlHLQr8BEvVMmTcpl3y2YY5y6gjSJa3g=!LCY!cache-lcy19249-LCY, dc/x3e9z8KMmlHLQr8BEvVMmTcpl3y2YY5y6gjSJa3g=!LCY!cache-lcy19227-LCY, dc/x3e9z8KMmlHLQr8BEvVMmTcpl3y2YY5y6gjSJa3g=!IAD!cache-iad2127-IAD, dc/x3e9z8KMmlHLQr8BEvVMmTcpl3y2YY5y6gjSJa3g=!IAD!cache-iad2133-IAD',
+    'Accept-Encoding': 'gzip',
+    'User-Agent':
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36',
+  },
+  repo: 'soupdemo',
+  ref: 'master',
+  selector: 'md',
+};
+
+const logger = winston.createLogger({
+  // tune this for debugging
+  level: 'debug',
+  // and turn this on if you want the output
+  silent: true,
+  format: winston.format.simple(),
+  transports: [
+    new winston.transports.Console(),
+  ],
+});
+
+/**
+ * Assert that a specific html dom is generated from the given markdown
+ * using our html pipeline.
+ *
+ * The comparison between generated html and given html is done on dom
+ * level, so differences not affecting the html (like most whitespace)
+ * are ignored.
+ *
+ * This may check multiple categories of template functions; currently
+ * the following classes are checked:
+ *
+ * * Ones rendering content.children
+ * * Ones rendering content.html
+ *
+ * @param {String} md The markdown to convert to html.
+ * @param {String} html The html we expect to be generated.
+ */
+const assertMd = async (md, html) => {
+  const fromChildren = ({ content }) => ({ response: { status: 201, body: content.children.join('\n') } });
+  const fromHTML = ({ content }) => ({ response: { status: 201, body: content.html } });
+
+  const expected = new JSDOM(html).window.document.body;
+  await Promise.all([fromChildren, fromHTML].map(async (fn) => {
+    const generated = await pipe(fn, { content: { body: md } }, { logger, request: { params } });
+    const actual = new JSDOM(generated.response.body).window.document.body;
+    assertEquivalentNode(actual, expected);
+  }));
+};
+
+/**
+ * Test a specific markdown feature.
+ *
+ * This is just a wrapper calling it and then issuing a single
+ * assertMd.
+ *
+ * @param {String} desc The description passed to it.
+ * @param {String} md The markdown passed to the pipeline.
+ * @param {String} html The html that is expected to be generated.
+ */
+const itMd = (desc, md, html) => {
+  it(desc, async () => {
+    await assertMd(md, html);
+  });
+};
+
+describe('Testing Markdown conversion', () => {
+  itMd('Renders empty markdown', '', '');
+});

--- a/test/testHTMLFromMarkdown.js
+++ b/test/testHTMLFromMarkdown.js
@@ -117,4 +117,30 @@ describe('Testing Markdown conversion', () => {
   itMd('Renders single paragraph', // Regression #157
     'Hello World.',
     '<p>Hello World.</p>');
+
+  it('Code blocks with lang', async () => {
+    await assertMd(
+      '```javascript\n```',
+      '<pre><code class="language-javascript"></code></pre>',
+    );
+    await assertMd(
+      '```javascript\nconsole.log(42);\n```',
+      '<pre><code class="language-javascript">console.log(42);\n</code></pre>',
+    );
+  });
+
+  it('Code blocks without lang', async () => {
+    await assertMd(
+      '    Hello World',
+      '<pre><code>Hello World\n</code></pre>',
+    );
+    await assertMd(
+      '```Hello World```',
+      '<p><code>Hello World</code></p>',
+    );
+    await assertMd(
+      '```\nHello World\n```',
+      '<pre><code>Hello World\n</code></pre>',
+    );
+  });
 });

--- a/test/testHTMLFromMarkdown.js
+++ b/test/testHTMLFromMarkdown.js
@@ -114,4 +114,7 @@ const itMd = (desc, md, html) => {
 
 describe('Testing Markdown conversion', () => {
   itMd('Renders empty markdown', '', '');
+  itMd('Renders single paragraph', // Regression #157
+    'Hello World.',
+    '<p>Hello World.</p>');
 });

--- a/test/testHTMLFromMarkdown.js
+++ b/test/testHTMLFromMarkdown.js
@@ -75,25 +75,25 @@ const logger = winston.createLogger({
  * level, so differences not affecting the html (like most whitespace)
  * are ignored.
  *
- * This may check multiple categories of template functions; currently
- * the following classes are checked:
- *
- * * Ones rendering content.children
- * * Ones rendering content.html
- *
  * @param {String} md The markdown to convert to html.
  * @param {String} html The html we expect to be generated.
  */
 const assertMd = async (md, html) => {
-  const fromChildren = ({ content }) => ({ response: { status: 201, body: content.children.join('\n') } });
   const fromHTML = ({ content }) => ({ response: { status: 201, body: content.html } });
 
-  const expected = new JSDOM(html).window.document.body;
-  await Promise.all([fromChildren, fromHTML].map(async (fn) => {
-    const generated = await pipe(fn, { content: { body: md } }, { logger, request: { params } });
-    const actual = new JSDOM(generated.response.body).window.document.body;
-    assertEquivalentNode(actual, expected);
-  }));
+  const generated = await pipe(
+    fromHTML,
+    { content: { body: md } },
+    {
+      logger,
+      request: { params },
+    },
+  );
+
+  assertEquivalentNode(
+    new JSDOM(generated.response.body).window.document.body,
+    new JSDOM(html).window.document.body,
+  );
 };
 
 /**


### PR DESCRIPTION
This fixes two issues with markdown rendering and adds an infrastructure for testing whether for a specific markdown input, the correct output is produced.

Not sure whether `test/testHTMLFromMarkdown.js` should not be merged into `test/testHTML.js`; I kind of like having all the markdown tests in their own place, on the other hand a lot of boilerplate is required to put them there…