### PR TITLE
md parser regression: setext headings no longer work #155

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -494,9 +494,9 @@
       }
     },
     "ajv": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
-      "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
+      "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/helix-pipeline",
-  "version": "0.11.1-pre.0",
+  "version": "0.11.1-pre.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/helix-pipeline",
-  "version": "0.11.1-pre.0",
+  "version": "0.11.1-pre.1",
   "description": "",
   "repository": "https://github.com/adobe/helix-pipeline",
   "main": "index.js",

--- a/src/html/parse-markdown.js
+++ b/src/html/parse-markdown.js
@@ -40,7 +40,7 @@ function parse({ content: { body = '' } = {} }, { logger }) {
   logger.debug(`Parsing markdown from request body starting with ${body.split('\n')[0]}`);
 
   const preprocessor = unified()
-    .use(remark, { setext: false })
+    .use(remark)
     .use(frontmatter, { type: 'yaml', marker: '-', anywhere: true });
 
   // see https://github.com/syntax-tree/mdast for documentation

--- a/src/html/parse-markdown.js
+++ b/src/html/parse-markdown.js
@@ -39,9 +39,6 @@ const thbreak = {
 function parse({ content: { body = '' } = {} }, { logger }) {
   logger.debug(`Parsing markdown from request body starting with ${body.split('\n')[0]}`);
 
-  // disable setext headings (=== and ---)
-  remark.Parser.prototype.blockTokenizers.setextHeading = () => {};
-
   const preprocessor = unified()
     .use(remark, { setext: false })
     .use(frontmatter, { type: 'yaml', marker: '-', anywhere: true });

--- a/test/fixtures/headings.json
+++ b/test/fixtures/headings.json
@@ -1,0 +1,84 @@
+{
+  "type": "root",
+  "children": [{
+      "children": [
+        {
+          "type": "text",
+          "value": "Heading 1 (double-underline)"
+        }
+      ],
+      "depth": 1,
+      "type": "heading"
+    },
+    {
+      "children": [
+        {
+          "type": "text",
+          "value": "Heading 2 (single-underline)"
+        }
+      ],
+      "depth": 2,
+      "type": "heading"
+    },
+    {
+      "children": [
+        {
+          "type": "text",
+          "value": "Heading 1"
+        }
+      ],
+      "depth": 1,
+      "type": "heading"
+    },
+    {
+      "children": [
+        {
+          "type": "text",
+          "value": "Heading 2"
+        }
+      ],
+      "depth": 2,
+      "type": "heading"
+    },
+    {
+      "children": [
+        {
+          "type": "text",
+          "value": "Heading 3"
+        }
+      ],
+      "depth": 3,
+      "type": "heading"
+    },
+    {
+      "children": [
+        {
+          "type": "text",
+          "value": "Heading 4"
+        }
+      ],
+      "depth": 4,
+      "type": "heading"
+    },
+    {
+      "children": [
+        {
+          "type": "text",
+          "value": "Heading 5"
+        }
+      ],
+      "depth": 5,
+      "type": "heading"
+    },
+    {
+      "children": [
+        {
+          "type": "text",
+          "value": "Heading 6"
+        }
+      ],
+      "depth": 6,
+      "type": "heading"
+    }
+  ]
+}

--- a/test/fixtures/headings.md
+++ b/test/fixtures/headings.md
@@ -1,0 +1,17 @@
+Heading 1 (double-underline)
+=========
+
+Heading 2 (single-underline)
+---------
+
+# Heading 1
+
+## Heading 2
+
+### Heading 3
+
+#### Heading 4
+
+##### Heading 5
+
+###### Heading 6

--- a/test/testParseMarkdown.js
+++ b/test/testParseMarkdown.js
@@ -37,7 +37,7 @@ describe('Test Markdown Parsing', () => {
   });
 
   // unskip once #155 is fixed
-  it.skip('Parses headings correctly', () => {
+  it('Parses headings correctly', () => {
     assertMatch('headings', callback);
   });
 

--- a/test/testParseMarkdown.js
+++ b/test/testParseMarkdown.js
@@ -36,7 +36,6 @@ describe('Test Markdown Parsing', () => {
     assertMatch('frontmatter', callback);
   });
 
-  // unskip once #155 is fixed
   it('Parses headings correctly', () => {
     assertMatch('headings', callback);
   });

--- a/test/testParseMarkdown.js
+++ b/test/testParseMarkdown.js
@@ -36,6 +36,11 @@ describe('Test Markdown Parsing', () => {
     assertMatch('frontmatter', callback);
   });
 
+  // unskip once #155 is fixed
+  it.skip('Parses headings correctly', () => {
+    assertMatch('headings', callback);
+  });
+
   it('Does not get confused by thematic breaks', () => {
     assertMatch('confusing', callback);
   });


### PR DESCRIPTION
As discussed in #155, I removed the line im parse-markdown.js that caused setext headings to be ignored. Also added a test to show that both setext and # headings are processed correctly.