### PR TITLE
Pollyjs update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -226,23 +226,24 @@
       }
     },
     "@pollyjs/adapter": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@pollyjs/adapter/-/adapter-1.4.1.tgz",
-      "integrity": "sha512-1CFoFkoFhP/DLhCIbTLpyIKr1jlzHWBTzL2WerE1loWLrCvnI+rw7YYfz2wJxEH9fuF25QRg5P3L2Yrvw5l3ig==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@pollyjs/adapter/-/adapter-2.2.0.tgz",
+      "integrity": "sha512-l6l3gWguDgfloPmmvGTUzEJNbo+LokOlQKgazWvTDwVTmUw6iQ2VAy798L+vMoLfqmp0H7ChZXdx1ReV29MgOA==",
       "dev": true,
       "requires": {
-        "@pollyjs/utils": "^1.4.1"
+        "@pollyjs/utils": "^2.1.0"
       }
     },
     "@pollyjs/adapter-node-http": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@pollyjs/adapter-node-http/-/adapter-node-http-1.4.1.tgz",
-      "integrity": "sha512-y+LW18NSzPEhSfyrU11dHCu/KSfa3ZA7lDsIWr0jGryA4yLnqO2bxiAJMFpEWx6UXigmRCRUyH9w4KehGS0FOA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@pollyjs/adapter-node-http/-/adapter-node-http-2.2.0.tgz",
+      "integrity": "sha512-HwBf4SWXBD7jaTkXQdU0nn5iNlrzVg+FttKT8S8qliSmC+qc4z4FthZv4cqUFNGaiycrw3gjxtiNPyL/+kc/9w==",
       "dev": true,
       "requires": {
-        "@pollyjs/adapter": "^1.4.1",
-        "@pollyjs/utils": "^1.4.1",
+        "@pollyjs/adapter": "^2.2.0",
+        "@pollyjs/utils": "^2.1.0",
         "lodash-es": "^4.17.11",
+        "nock": "^10.0.6",
         "semver": "^5.6.0"
       },
       "dependencies": {
@@ -255,12 +256,12 @@
       }
     },
     "@pollyjs/core": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@pollyjs/core/-/core-1.4.1.tgz",
-      "integrity": "sha512-uUp+e9FK8CAlXjgiXAFutvTAciWY9k2wddyCk73+TJybjZzzchL4QBrOQ1TYbs8DKVQoGfoRnBNypqDT2vOt+w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@pollyjs/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-HHbv6gzsJ6WiKug9s+JUkQmjE010O1ElNS776VmJ5UvX+cdHYccAtjETCbQKEKzCIi71oa7+FAPUwO+MSuRbfA==",
       "dev": true,
       "requires": {
-        "@pollyjs/utils": "^1.4.1",
+        "@pollyjs/utils": "^2.1.0",
         "@sindresorhus/fnv1a": "^1.0.0",
         "blueimp-md5": "^2.10.0",
         "fast-json-stable-stringify": "^2.0.0",
@@ -358,9 +359,9 @@
       }
     },
     "@pollyjs/utils": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@pollyjs/utils/-/utils-1.4.1.tgz",
-      "integrity": "sha512-UVIgsj50LBdWZfcUY+Yh0NU9sciLtUW75kqqgnPCagUYnYpsENiih1+C83zs4IcPR7kbuBht8z2EMxeD1tf+qg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@pollyjs/utils/-/utils-2.1.0.tgz",
+      "integrity": "sha512-psHTlcQZuKxG9ZACzcCo/omOFc4LbYRx4ASjWxR7TmOZKzcR653R0/APL8SXGRfGPD8RsFOGSSbXzjXyUX+g7A==",
       "dev": true,
       "requires": {
         "qs": "^6.6.0",
@@ -717,6 +718,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -1265,6 +1272,20 @@
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.3.tgz",
       "integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw=="
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
@@ -1306,6 +1327,12 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "ci-info": {
@@ -1767,6 +1794,21 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -3096,6 +3138,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "get-stream": {
@@ -5239,6 +5287,34 @@
       "integrity": "sha1-ICtIAhoMTL3i34DeFaF0Q8i0OYA=",
       "dev": true
     },
+    "nock": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz",
+      "integrity": "sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==",
+      "dev": true,
+      "requires": {
+        "chai": "^4.1.2",
+        "debug": "^4.1.0",
+        "deep-equal": "^1.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.5",
+        "mkdirp": "^0.5.0",
+        "propagate": "^1.0.0",
+        "qs": "^6.5.1",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "node-environment-flags": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.4.tgz",
@@ -6760,6 +6836,12 @@
         }
       }
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -6857,6 +6939,12 @@
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
       }
+    },
+    "propagate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "dev": true
     },
     "property-information": {
       "version": "5.0.1",
@@ -8477,6 +8565,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.16",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@adobe/jsonschema2md": "^1.1.1-SNAPSHOT.236",
-    "@pollyjs/adapter-node-http": "^1.4.1",
-    "@pollyjs/core": "^1.4.1",
+    "@pollyjs/adapter-node-http": "^2.2.0",
+    "@pollyjs/core": "^2.2.0",
     "@pollyjs/persister-fs": "^2.1.0",
     "codecov": "^3.0.2",
     "eslint": "^5.6.1",

--- a/src/html/fetch-markdown.js
+++ b/src/html/fetch-markdown.js
@@ -84,6 +84,7 @@ async function fetch(
     uri: uri(rootPath, owner, repo, ref, path),
     json: false,
     timeout,
+    time: true,
   };
   logger.debug(`fetching Markdown from ${options.uri}`);
   try {
@@ -97,7 +98,7 @@ async function fetch(
   } catch (e) {
     if (e && e.statusCode && e.statusCode === 404) {
       return bail(logger, `Could not find Markdown at ${options.uri}`, e, 404);
-    } if (e && e.cause && e.cause.code && (e.cause.code === 'ESOCKETTIMEDOUT' || e.cause.code === 'ETIMEDOUT')) {
+    } if ((e && e.response && e.response.elapsedTime && e.response.elapsedTime > timeout) || (e && e.cause && e.cause.code && (e.cause.code === 'ESOCKETTIMEDOUT' || e.cause.code === 'ETIMEDOUT'))) {
       // return gateway timeout
       return bail(logger, `Gateway timout of ${timeout} milliseconds exceeded for ${options.uri}`, e, 504);
     }

--- a/test/fixtures/Test-non-existing-content_3508203637/Getting-XDM-README-from-wrong-URL-_3748211873/recording.har
+++ b/test/fixtures/Test-non-existing-content_3508203637/Getting-XDM-README-from-wrong-URL-_3748211873/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "a87c74d1e664eb347fa63940bf496e07",
+        "_id": "3f25a666522e98899fdb8870d64e3462",
         "_order": 0,
         "cache": {},
         "request": {
@@ -23,9 +23,6 @@
           "headersSize": 111,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "postData": {
-            "mimeType": "text/plain"
-          },
           "queryString": [],
           "url": "https://raw.githubusercontent.com/nobody/xdm/master/README.md"
         },
@@ -60,7 +57,7 @@
             },
             {
               "name": "x-github-request-id",
-              "value": "7D2E:45A3:27203E:2B9AD4:5C1A751A"
+              "value": "97F8:6405:1EE70B:2131A6:5C7528E7"
             },
             {
               "name": "content-length",
@@ -72,7 +69,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 19 Dec 2018 16:43:06 GMT"
+              "value": "Tue, 26 Feb 2019 11:54:16 GMT"
             },
             {
               "name": "via",
@@ -84,7 +81,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-fra19128-FRA"
+              "value": "cache-hhn1523-HHN"
             },
             {
               "name": "x-cache",
@@ -96,7 +93,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1545237787.868586,VS0,VE126"
+              "value": "S1551182056.876842,VS0,VE150"
             },
             {
               "name": "vary",
@@ -108,25 +105,25 @@
             },
             {
               "name": "x-fastly-request-id",
-              "value": "a1ca3cca4b2f30019d7780dfb68c18b94295dbad"
+              "value": "b6fcbc3c2c273f0957dd789213ec13d5ec3fd1ec"
             },
             {
               "name": "expires",
-              "value": "Wed, 19 Dec 2018 16:48:06 GMT"
+              "value": "Tue, 26 Feb 2019 11:59:16 GMT"
             },
             {
               "name": "source-age",
               "value": "0"
             }
           ],
-          "headersSize": 679,
+          "headersSize": 678,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 404,
           "statusText": "Not Found"
         },
-        "startedDateTime": "2018-12-19T16:43:06.723Z",
-        "time": 297,
+        "startedDateTime": "2019-02-26T11:54:15.734Z",
+        "time": 318,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -134,7 +131,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 297
+          "wait": 318
         }
       }
     ],

--- a/test/fixtures/Test-non-existing-content_3508203637/Getting-XDM-README-with-missing-ref-_3627027906/recording.har
+++ b/test/fixtures/Test-non-existing-content_3508203637/Getting-XDM-README-with-missing-ref-_3627027906/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "0587e71713ca5954accfb3d6415d740d",
+        "_id": "8801a2001578e12b49266529916516fa",
         "_order": 0,
         "cache": {},
         "request": {
@@ -23,9 +23,6 @@
           "headersSize": 110,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "postData": {
-            "mimeType": "text/plain"
-          },
           "queryString": [],
           "url": "https://raw.githubusercontent.com/adobe/xdm/master/README.md"
         },
@@ -71,8 +68,12 @@
               "value": "max-age=300"
             },
             {
+              "name": "x-geo-block-list",
+              "value": ""
+            },
+            {
               "name": "x-github-request-id",
-              "value": "F350:21DE:5D861E:65EDC8:5C1A99AE"
+              "value": "6C32:3C19:24655:28F0A:5C7528E7"
             },
             {
               "name": "content-length",
@@ -84,7 +85,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 19 Dec 2018 19:19:11 GMT"
+              "value": "Tue, 26 Feb 2019 11:54:16 GMT"
             },
             {
               "name": "via",
@@ -96,7 +97,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-fra19146-FRA"
+              "value": "cache-hhn1523-HHN"
             },
             {
               "name": "x-cache",
@@ -108,7 +109,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1545247151.911195,VS0,VE121"
+              "value": "S1551182056.166211,VS0,VE175"
             },
             {
               "name": "vary",
@@ -120,25 +121,25 @@
             },
             {
               "name": "x-fastly-request-id",
-              "value": "64ee8cd853d3822702a6e74dcc2cd59d3bcc338c"
+              "value": "7f52450f2a7789ea83625f4d1e80a661dbe1e8f0"
             },
             {
               "name": "expires",
-              "value": "Wed, 19 Dec 2018 19:24:11 GMT"
+              "value": "Tue, 26 Feb 2019 11:59:16 GMT"
             },
             {
               "name": "source-age",
               "value": "0"
             }
           ],
-          "headersSize": 800,
+          "headersSize": 817,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2018-12-19T19:19:10.797Z",
-        "time": 277,
+        "startedDateTime": "2019-02-26T11:54:16.092Z",
+        "time": 269,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -146,7 +147,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 277
+          "wait": 269
         }
       }
     ],

--- a/test/fixtures/Test-requests_3022673737/Getting-XDM-README_4219425422/recording.har
+++ b/test/fixtures/Test-requests_3022673737/Getting-XDM-README_4219425422/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "0587e71713ca5954accfb3d6415d740d",
+        "_id": "8801a2001578e12b49266529916516fa",
         "_order": 0,
         "cache": {},
         "request": {
@@ -23,9 +23,6 @@
           "headersSize": 110,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "postData": {
-            "mimeType": "text/plain"
-          },
           "queryString": [],
           "url": "https://raw.githubusercontent.com/adobe/xdm/master/README.md"
         },
@@ -71,8 +68,12 @@
               "value": "max-age=300"
             },
             {
+              "name": "x-geo-block-list",
+              "value": ""
+            },
+            {
               "name": "x-github-request-id",
-              "value": "BF7E:21DE:587F68:607A88:5C1A7449"
+              "value": "6C32:3C19:24655:28F0A:5C7528E7"
             },
             {
               "name": "content-length",
@@ -84,7 +85,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 19 Dec 2018 16:44:15 GMT"
+              "value": "Tue, 26 Feb 2019 11:54:16 GMT"
             },
             {
               "name": "via",
@@ -96,7 +97,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-fra19148-FRA"
+              "value": "cache-hhn1549-HHN"
             },
             {
               "name": "x-cache",
@@ -108,7 +109,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1545237856.800624,VS0,VE1"
+              "value": "S1551182056.438182,VS0,VE0"
             },
             {
               "name": "vary",
@@ -120,25 +121,25 @@
             },
             {
               "name": "x-fastly-request-id",
-              "value": "d2a89ee10e31b22560c616382fa1ab572f2dae45"
+              "value": "197ac7a670d68c74a0067da6f3f5244c40539d2c"
             },
             {
               "name": "expires",
-              "value": "Wed, 19 Dec 2018 16:49:15 GMT"
+              "value": "Tue, 26 Feb 2019 11:59:16 GMT"
             },
             {
               "name": "source-age",
-              "value": "278"
+              "value": "0"
             }
           ],
-          "headersSize": 799,
+          "headersSize": 814,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2018-12-19T16:44:15.169Z",
-        "time": 744,
+        "startedDateTime": "2019-02-26T11:54:16.376Z",
+        "time": 82,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -146,7 +147,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 744
+          "wait": 82
         }
       }
     ],

--- a/test/fixtures/Testing-HTML-Pipeline_3038423338/html-pipe-keeps-existing-headers_3629209091/recording.har
+++ b/test/fixtures/Testing-HTML-Pipeline_3038423338/html-pipe-keeps-existing-headers_3629209091/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "f6d21213aea4a5155bf5ebb41ef6650e",
+        "_id": "718996af3803e62c740c1b7eef8fb81e",
         "_order": 0,
         "cache": {},
         "request": {
@@ -23,9 +23,6 @@
           "headersSize": 117,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "postData": {
-            "mimeType": "text/plain"
-          },
           "queryString": [],
           "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/hello.md"
         },
@@ -71,8 +68,12 @@
               "value": "max-age=300"
             },
             {
+              "name": "x-geo-block-list",
+              "value": ""
+            },
+            {
               "name": "x-github-request-id",
-              "value": "1DA8:15DD:368E4F:3C7951:5C1A7B3D"
+              "value": "A784:3615:21A12C:24128E:5C7528EA"
             },
             {
               "name": "content-length",
@@ -84,7 +85,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 19 Dec 2018 17:09:25 GMT"
+              "value": "Tue, 26 Feb 2019 11:54:19 GMT"
             },
             {
               "name": "via",
@@ -96,7 +97,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-fra19147-FRA"
+              "value": "cache-hhn1522-HHN"
             },
             {
               "name": "x-cache",
@@ -104,11 +105,11 @@
             },
             {
               "name": "x-cache-hits",
-              "value": "1"
+              "value": "2"
             },
             {
               "name": "x-timer",
-              "value": "S1545239365.474063,VS0,VE0"
+              "value": "S1551182060.978799,VS0,VE0"
             },
             {
               "name": "vary",
@@ -120,25 +121,25 @@
             },
             {
               "name": "x-fastly-request-id",
-              "value": "95e89525d7670f3296b96b9e3ea29f5208a8e56c"
+              "value": "9cfb0bc81f25b37617b3776d2dc861c53a115375"
             },
             {
               "name": "expires",
-              "value": "Wed, 19 Dec 2018 17:14:25 GMT"
+              "value": "Tue, 26 Feb 2019 11:59:19 GMT"
             },
             {
               "name": "source-age",
-              "value": "7"
+              "value": "0"
             }
           ],
-          "headersSize": 796,
+          "headersSize": 815,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2018-12-19T17:09:25.412Z",
-        "time": 107,
+        "startedDateTime": "2019-02-26T11:54:19.919Z",
+        "time": 78,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -146,7 +147,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 107
+          "wait": 78
         }
       }
     ],

--- a/test/fixtures/Testing-HTML-Pipeline_3038423338/html-pipe-makes-HTTP-requests-and-falls-back-to-master_2961813882/recording.har
+++ b/test/fixtures/Testing-HTML-Pipeline_3038423338/html-pipe-makes-HTTP-requests-and-falls-back-to-master_2961813882/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "f6d21213aea4a5155bf5ebb41ef6650e",
+        "_id": "718996af3803e62c740c1b7eef8fb81e",
         "_order": 0,
         "cache": {},
         "request": {
@@ -23,9 +23,6 @@
           "headersSize": 117,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "postData": {
-            "mimeType": "text/plain"
-          },
           "queryString": [],
           "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/hello.md"
         },
@@ -71,8 +68,12 @@
               "value": "max-age=300"
             },
             {
+              "name": "x-geo-block-list",
+              "value": ""
+            },
+            {
               "name": "x-github-request-id",
-              "value": "6A6C:15DD:395983:3F8C11:5C1A99AF"
+              "value": "A784:3615:21A12C:24128E:5C7528EA"
             },
             {
               "name": "content-length",
@@ -84,7 +85,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 19 Dec 2018 19:19:11 GMT"
+              "value": "Tue, 26 Feb 2019 11:54:19 GMT"
             },
             {
               "name": "via",
@@ -96,19 +97,19 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-fra19139-FRA"
+              "value": "cache-hhn1522-HHN"
             },
             {
               "name": "x-cache",
-              "value": "MISS"
+              "value": "HIT"
             },
             {
               "name": "x-cache-hits",
-              "value": "0"
+              "value": "1"
             },
             {
               "name": "x-timer",
-              "value": "S1545247152.862247,VS0,VE112"
+              "value": "S1551182060.615531,VS0,VE0"
             },
             {
               "name": "vary",
@@ -120,25 +121,25 @@
             },
             {
               "name": "x-fastly-request-id",
-              "value": "50374a0fe27e855e936e681de850ed48a406ec41"
+              "value": "625e68d906d47dce90682af3e08927e3b5bba512"
             },
             {
               "name": "expires",
-              "value": "Wed, 19 Dec 2018 19:24:11 GMT"
+              "value": "Tue, 26 Feb 2019 11:59:19 GMT"
             },
             {
               "name": "source-age",
               "value": "0"
             }
           ],
-          "headersSize": 799,
+          "headersSize": 815,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2018-12-19T19:19:11.786Z",
-        "time": 223,
+        "startedDateTime": "2019-02-26T11:54:19.554Z",
+        "time": 82,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -146,7 +147,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 223
+          "wait": 82
         }
       }
     ],

--- a/test/fixtures/Testing-HTML-Pipeline_3038423338/html-pipe-makes-HTTP-requests_1846604431/recording.har
+++ b/test/fixtures/Testing-HTML-Pipeline_3038423338/html-pipe-makes-HTTP-requests_1846604431/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "f6d21213aea4a5155bf5ebb41ef6650e",
+        "_id": "718996af3803e62c740c1b7eef8fb81e",
         "_order": 0,
         "cache": {},
         "request": {
@@ -23,9 +23,6 @@
           "headersSize": 117,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "postData": {
-            "mimeType": "text/plain"
-          },
           "queryString": [],
           "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/hello.md"
         },
@@ -71,8 +68,12 @@
               "value": "max-age=300"
             },
             {
+              "name": "x-geo-block-list",
+              "value": ""
+            },
+            {
               "name": "x-github-request-id",
-              "value": "1DA8:15DD:368E4F:3C7951:5C1A7B3D"
+              "value": "A784:3615:21A12C:24128E:5C7528EA"
             },
             {
               "name": "content-length",
@@ -84,7 +85,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 19 Dec 2018 17:09:18 GMT"
+              "value": "Tue, 26 Feb 2019 11:54:19 GMT"
             },
             {
               "name": "via",
@@ -96,7 +97,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-fra19151-FRA"
+              "value": "cache-hhn1549-HHN"
             },
             {
               "name": "x-cache",
@@ -108,7 +109,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1545239358.889715,VS0,VE127"
+              "value": "S1551182059.196246,VS0,VE284"
             },
             {
               "name": "vary",
@@ -120,25 +121,25 @@
             },
             {
               "name": "x-fastly-request-id",
-              "value": "402096c1ee5e36d29f5958607ee5acf4d26b5fc1"
+              "value": "945e05abb0a1900255934a828097ce0cd2b0c12c"
             },
             {
               "name": "expires",
-              "value": "Wed, 19 Dec 2018 17:14:18 GMT"
+              "value": "Tue, 26 Feb 2019 11:59:19 GMT"
             },
             {
               "name": "source-age",
               "value": "0"
             }
           ],
-          "headersSize": 799,
+          "headersSize": 818,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2018-12-19T17:09:17.821Z",
-        "time": 238,
+        "startedDateTime": "2019-02-26T11:54:19.138Z",
+        "time": 363,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -146,7 +147,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 238
+          "wait": 363
         }
       }
     ],

--- a/test/fixtures/Testing-HTML-Pipeline_3038423338/html-pipe-produces-debug-dumps_816111615/recording.har
+++ b/test/fixtures/Testing-HTML-Pipeline_3038423338/html-pipe-produces-debug-dumps_816111615/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "f6d21213aea4a5155bf5ebb41ef6650e",
+        "_id": "718996af3803e62c740c1b7eef8fb81e",
         "_order": 0,
         "cache": {},
         "request": {
@@ -23,9 +23,6 @@
           "headersSize": 117,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "postData": {
-            "mimeType": "text/plain"
-          },
           "queryString": [],
           "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/hello.md"
         },
@@ -71,8 +68,12 @@
               "value": "max-age=300"
             },
             {
+              "name": "x-geo-block-list",
+              "value": ""
+            },
+            {
               "name": "x-github-request-id",
-              "value": "1DA8:15DD:368E4F:3C7951:5C1A7B3D"
+              "value": "A784:3615:21A12C:24128E:5C7528EA"
             },
             {
               "name": "content-length",
@@ -84,7 +85,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 19 Dec 2018 17:09:25 GMT"
+              "value": "Tue, 26 Feb 2019 11:54:20 GMT"
             },
             {
               "name": "via",
@@ -96,7 +97,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-fra19140-FRA"
+              "value": "cache-hhn1544-HHN"
             },
             {
               "name": "x-cache",
@@ -108,7 +109,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1545239366.633474,VS0,VE1"
+              "value": "S1551182060.113740,VS0,VE1"
             },
             {
               "name": "vary",
@@ -120,25 +121,25 @@
             },
             {
               "name": "x-fastly-request-id",
-              "value": "c51995d11cf71fe3bdd2d74539b524150e3fcb77"
+              "value": "e503d2a918f3c9cc221ebe79c5ba447fc190d82b"
             },
             {
               "name": "expires",
-              "value": "Wed, 19 Dec 2018 17:14:25 GMT"
+              "value": "Tue, 26 Feb 2019 11:59:20 GMT"
             },
             {
               "name": "source-age",
-              "value": "8"
+              "value": "1"
             }
           ],
-          "headersSize": 796,
+          "headersSize": 815,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2018-12-19T17:09:25.572Z",
-        "time": 105,
+        "startedDateTime": "2019-02-26T11:54:20.056Z",
+        "time": 79,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -146,7 +147,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 105
+          "wait": 79
         }
       }
     ],

--- a/test/fixtures/Testing-HTML-Pipeline_3038423338/html-pipe-serves-404-for-non-existent-content_254320879/recording.har
+++ b/test/fixtures/Testing-HTML-Pipeline_3038423338/html-pipe-serves-404-for-non-existent-content_254320879/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "f344b8c35f7084c724bbf6f47bd40f1d",
+        "_id": "f627c1277171a88083a8617ffbf6a063",
         "_order": 0,
         "cache": {},
         "request": {
@@ -23,9 +23,6 @@
           "headersSize": 129,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "postData": {
-            "mimeType": "text/plain"
-          },
           "queryString": [],
           "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/non_existent_file.md"
         },
@@ -60,7 +57,7 @@
             },
             {
               "name": "x-github-request-id",
-              "value": "D06C:763C:4D1F3D:53C72B:5C1A7B44"
+              "value": "7216:17E9:22D35:27484:5C7528EB"
             },
             {
               "name": "content-length",
@@ -72,7 +69,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 19 Dec 2018 17:09:25 GMT"
+              "value": "Tue, 26 Feb 2019 11:54:19 GMT"
             },
             {
               "name": "via",
@@ -84,7 +81,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-fra19128-FRA"
+              "value": "cache-hhn1531-HHN"
             },
             {
               "name": "x-cache",
@@ -96,7 +93,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1545239365.219972,VS0,VE117"
+              "value": "S1551182060.738028,VS0,VE132"
             },
             {
               "name": "vary",
@@ -108,25 +105,25 @@
             },
             {
               "name": "x-fastly-request-id",
-              "value": "1cd9bd66a22f8c5e4ea7d495d00585c91e572754"
+              "value": "f6108bbdedadc8d794fa7a8e2d4da960a40388fb"
             },
             {
               "name": "expires",
-              "value": "Wed, 19 Dec 2018 17:14:25 GMT"
+              "value": "Tue, 26 Feb 2019 11:59:19 GMT"
             },
             {
               "name": "source-age",
               "value": "0"
             }
           ],
-          "headersSize": 679,
+          "headersSize": 676,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 404,
           "statusText": "Not Found"
         },
-        "startedDateTime": "2018-12-19T17:09:25.160Z",
-        "time": 229,
+        "startedDateTime": "2019-02-26T11:54:19.680Z",
+        "time": 209,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -134,7 +131,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 229
+          "wait": 209
         }
       }
     ],

--- a/test/fixtures/Testing-JSON-Pipeline_1774802251/json-pipe-keeps-Mime-Type_3820175046/recording.har
+++ b/test/fixtures/Testing-JSON-Pipeline_1774802251/json-pipe-keeps-Mime-Type_3820175046/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "f6d21213aea4a5155bf5ebb41ef6650e",
+        "_id": "718996af3803e62c740c1b7eef8fb81e",
         "_order": 0,
         "cache": {},
         "request": {
@@ -23,9 +23,6 @@
           "headersSize": 117,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "postData": {
-            "mimeType": "text/plain"
-          },
           "queryString": [],
           "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/hello.md"
         },
@@ -71,8 +68,12 @@
               "value": "max-age=300"
             },
             {
+              "name": "x-geo-block-list",
+              "value": ""
+            },
+            {
               "name": "x-github-request-id",
-              "value": "1DA8:15DD:368E4F:3C7951:5C1A7B3D"
+              "value": "A784:3615:21A12C:24128E:5C7528EA"
             },
             {
               "name": "content-length",
@@ -84,7 +85,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 19 Dec 2018 17:11:07 GMT"
+              "value": "Tue, 26 Feb 2019 11:54:20 GMT"
             },
             {
               "name": "via",
@@ -96,7 +97,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-fra19126-FRA"
+              "value": "cache-hhn1525-HHN"
             },
             {
               "name": "x-cache",
@@ -108,7 +109,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1545239468.947393,VS0,VE1"
+              "value": "S1551182061.772497,VS0,VE1"
             },
             {
               "name": "vary",
@@ -120,25 +121,25 @@
             },
             {
               "name": "x-fastly-request-id",
-              "value": "ee56575cd43f2a27889b2827e32dcee6650520b0"
+              "value": "5ef9c3b31d7d9eeffc19a118e0daaa03bc659a2f"
             },
             {
               "name": "expires",
-              "value": "Wed, 19 Dec 2018 17:16:07 GMT"
+              "value": "Tue, 26 Feb 2019 11:59:20 GMT"
             },
             {
               "name": "source-age",
-              "value": "110"
+              "value": "1"
             }
           ],
-          "headersSize": 798,
+          "headersSize": 815,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2018-12-19T17:11:07.847Z",
-        "time": 127,
+        "startedDateTime": "2019-02-26T11:54:20.715Z",
+        "time": 79,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -146,7 +147,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 127
+          "wait": 79
         }
       }
     ],

--- a/test/fixtures/Testing-JSON-Pipeline_1774802251/json-pipe-makes-HTTP-requests_1827123166/recording.har
+++ b/test/fixtures/Testing-JSON-Pipeline_1774802251/json-pipe-makes-HTTP-requests_1827123166/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "f6d21213aea4a5155bf5ebb41ef6650e",
+        "_id": "718996af3803e62c740c1b7eef8fb81e",
         "_order": 0,
         "cache": {},
         "request": {
@@ -23,9 +23,6 @@
           "headersSize": 117,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "postData": {
-            "mimeType": "text/plain"
-          },
           "queryString": [],
           "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/hello.md"
         },
@@ -71,8 +68,12 @@
               "value": "max-age=300"
             },
             {
+              "name": "x-geo-block-list",
+              "value": ""
+            },
+            {
               "name": "x-github-request-id",
-              "value": "1DA8:15DD:368E4F:3C7951:5C1A7B3D"
+              "value": "A784:3615:21A12C:24128E:5C7528EA"
             },
             {
               "name": "content-length",
@@ -84,7 +85,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 19 Dec 2018 17:11:07 GMT"
+              "value": "Tue, 26 Feb 2019 11:54:20 GMT"
             },
             {
               "name": "via",
@@ -96,7 +97,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-fra19145-FRA"
+              "value": "cache-hhn1550-HHN"
             },
             {
               "name": "x-cache",
@@ -108,7 +109,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1545239468.690359,VS0,VE1"
+              "value": "S1551182061.674429,VS0,VE1"
             },
             {
               "name": "vary",
@@ -120,25 +121,25 @@
             },
             {
               "name": "x-fastly-request-id",
-              "value": "91b6c67519dda1e5edcc01f9429f6e8ea7aa1b62"
+              "value": "950eb0c5a5724ebd763843b022773c79d7069153"
             },
             {
               "name": "expires",
-              "value": "Wed, 19 Dec 2018 17:16:07 GMT"
+              "value": "Tue, 26 Feb 2019 11:59:20 GMT"
             },
             {
               "name": "source-age",
-              "value": "110"
+              "value": "1"
             }
           ],
-          "headersSize": 798,
+          "headersSize": 815,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2018-12-19T17:11:07.598Z",
-        "time": 126,
+        "startedDateTime": "2019-02-26T11:54:20.615Z",
+        "time": 79,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -146,7 +147,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 126
+          "wait": 79
         }
       }
     ],

--- a/test/fixtures/Testing-XML-Pipeline_1741549992/xml-pipe-detects-ESI-tag-in-XML-object_3288113526/recording.har
+++ b/test/fixtures/Testing-XML-Pipeline_1741549992/xml-pipe-detects-ESI-tag-in-XML-object_3288113526/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "f6d21213aea4a5155bf5ebb41ef6650e",
+        "_id": "718996af3803e62c740c1b7eef8fb81e",
         "_order": 0,
         "cache": {},
         "request": {
@@ -23,9 +23,6 @@
           "headersSize": 117,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "postData": {
-            "mimeType": "text/plain"
-          },
           "queryString": [],
           "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/hello.md"
         },
@@ -71,8 +68,12 @@
               "value": "max-age=300"
             },
             {
+              "name": "x-geo-block-list",
+              "value": ""
+            },
+            {
               "name": "x-github-request-id",
-              "value": "1DA8:15DD:368E4F:3C7951:5C1A7B3D"
+              "value": "A784:3615:21A12C:24128E:5C7528EA"
             },
             {
               "name": "content-length",
@@ -84,7 +85,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 19 Dec 2018 17:12:57 GMT"
+              "value": "Tue, 26 Feb 2019 11:54:21 GMT"
             },
             {
               "name": "via",
@@ -96,7 +97,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-fra19125-FRA"
+              "value": "cache-hhn1541-HHN"
             },
             {
               "name": "x-cache",
@@ -108,7 +109,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1545239577.014261,VS0,VE0"
+              "value": "S1551182062.784700,VS0,VE0"
             },
             {
               "name": "vary",
@@ -120,25 +121,25 @@
             },
             {
               "name": "x-fastly-request-id",
-              "value": "1bb562596da0a8ba93561cf3c781c827395eed57"
+              "value": "7fe1a5940ea4f0214ef9f570557f663cc937c3eb"
             },
             {
               "name": "expires",
-              "value": "Wed, 19 Dec 2018 17:17:57 GMT"
+              "value": "Tue, 26 Feb 2019 11:59:21 GMT"
             },
             {
               "name": "source-age",
-              "value": "219"
+              "value": "2"
             }
           ],
-          "headersSize": 798,
+          "headersSize": 815,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2018-12-19T17:12:56.954Z",
-        "time": 109,
+        "startedDateTime": "2019-02-26T11:54:21.728Z",
+        "time": 80,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -146,7 +147,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 109
+          "wait": 80
         }
       }
     ],

--- a/test/fixtures/Testing-XML-Pipeline_1741549992/xml-pipe-makes-HTTP-requests_607214737/recording.har
+++ b/test/fixtures/Testing-XML-Pipeline_1741549992/xml-pipe-makes-HTTP-requests_607214737/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "f6d21213aea4a5155bf5ebb41ef6650e",
+        "_id": "718996af3803e62c740c1b7eef8fb81e",
         "_order": 0,
         "cache": {},
         "request": {
@@ -23,9 +23,6 @@
           "headersSize": 117,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "postData": {
-            "mimeType": "text/plain"
-          },
           "queryString": [],
           "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/hello.md"
         },
@@ -71,8 +68,12 @@
               "value": "max-age=300"
             },
             {
+              "name": "x-geo-block-list",
+              "value": ""
+            },
+            {
               "name": "x-github-request-id",
-              "value": "1DA8:15DD:368E4F:3C7951:5C1A7B3D"
+              "value": "A784:3615:21A12C:24128E:5C7528EA"
             },
             {
               "name": "content-length",
@@ -84,7 +85,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 19 Dec 2018 17:12:56 GMT"
+              "value": "Tue, 26 Feb 2019 11:54:21 GMT"
             },
             {
               "name": "via",
@@ -96,7 +97,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-fra19144-FRA"
+              "value": "cache-hhn1545-HHN"
             },
             {
               "name": "x-cache",
@@ -104,11 +105,11 @@
             },
             {
               "name": "x-cache-hits",
-              "value": "5"
+              "value": "1"
             },
             {
               "name": "x-timer",
-              "value": "S1545239576.247026,VS0,VE0"
+              "value": "S1551182061.352282,VS0,VE1"
             },
             {
               "name": "vary",
@@ -120,25 +121,25 @@
             },
             {
               "name": "x-fastly-request-id",
-              "value": "640531c78ed0148742f29db7f0b9b374efce9b01"
+              "value": "0e1e71502aa798abe0b9e4e8eb5e948ed2fbbfd6"
             },
             {
               "name": "expires",
-              "value": "Wed, 19 Dec 2018 17:17:56 GMT"
+              "value": "Tue, 26 Feb 2019 11:59:21 GMT"
             },
             {
               "name": "source-age",
-              "value": "218"
+              "value": "2"
             }
           ],
-          "headersSize": 798,
+          "headersSize": 815,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2018-12-19T17:12:56.181Z",
-        "time": 117,
+        "startedDateTime": "2019-02-26T11:54:21.291Z",
+        "time": 83,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -146,7 +147,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 117
+          "wait": 83
         }
       }
     ],

--- a/test/fixtures/Testing-XML-Pipeline_1741549992/xml-pipe-serves-404-for-non-existent-content_1812732349/recording.har
+++ b/test/fixtures/Testing-XML-Pipeline_1741549992/xml-pipe-serves-404-for-non-existent-content_1812732349/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "f344b8c35f7084c724bbf6f47bd40f1d",
+        "_id": "f627c1277171a88083a8617ffbf6a063",
         "_order": 0,
         "cache": {},
         "request": {
@@ -23,9 +23,6 @@
           "headersSize": 129,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "postData": {
-            "mimeType": "text/plain"
-          },
           "queryString": [],
           "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/non_existent_file.md"
         },
@@ -60,7 +57,7 @@
             },
             {
               "name": "x-github-request-id",
-              "value": "AFE0:763C:4D42F6:53ED2B:5C1A7C18"
+              "value": "7216:17E9:22D35:27484:5C7528EB"
             },
             {
               "name": "content-length",
@@ -72,7 +69,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 19 Dec 2018 17:12:56 GMT"
+              "value": "Tue, 26 Feb 2019 11:54:21 GMT"
             },
             {
               "name": "via",
@@ -84,19 +81,19 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-fra19133-FRA"
+              "value": "cache-hhn1549-HHN"
             },
             {
               "name": "x-cache",
-              "value": "MISS"
+              "value": "HIT"
             },
             {
               "name": "x-cache-hits",
-              "value": "0"
+              "value": "1"
             },
             {
               "name": "x-timer",
-              "value": "S1545239577.753160,VS0,VE136"
+              "value": "S1551182062.688520,VS0,VE0"
             },
             {
               "name": "vary",
@@ -108,25 +105,25 @@
             },
             {
               "name": "x-fastly-request-id",
-              "value": "a78a19c567d48679f12ce111a677e9da1db48766"
+              "value": "eca4f21c147f620db8e183a35516fc289b97a577"
             },
             {
               "name": "expires",
-              "value": "Wed, 19 Dec 2018 17:17:56 GMT"
+              "value": "Tue, 26 Feb 2019 11:59:21 GMT"
             },
             {
               "name": "source-age",
-              "value": "0"
+              "value": "2"
             }
           ],
-          "headersSize": 679,
+          "headersSize": 673,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 404,
           "statusText": "Not Found"
         },
-        "startedDateTime": "2018-12-19T17:12:56.687Z",
-        "time": 246,
+        "startedDateTime": "2019-02-26T11:54:21.633Z",
+        "time": 78,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -134,7 +131,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 246
+          "wait": 78
         }
       }
     ],

--- a/test/fixtures/Testing-XML-Pipeline_1741549992/xmp-pipe-does-not-overwrite-existing-respone-body_988789528/recording.har
+++ b/test/fixtures/Testing-XML-Pipeline_1741549992/xmp-pipe-does-not-overwrite-existing-respone-body_988789528/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "f6d21213aea4a5155bf5ebb41ef6650e",
+        "_id": "718996af3803e62c740c1b7eef8fb81e",
         "_order": 0,
         "cache": {},
         "request": {
@@ -23,9 +23,6 @@
           "headersSize": 117,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "postData": {
-            "mimeType": "text/plain"
-          },
           "queryString": [],
           "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/hello.md"
         },
@@ -71,8 +68,12 @@
               "value": "max-age=300"
             },
             {
+              "name": "x-geo-block-list",
+              "value": ""
+            },
+            {
               "name": "x-github-request-id",
-              "value": "1DA8:15DD:368E4F:3C7951:5C1A7B3D"
+              "value": "A784:3615:21A12C:24128E:5C7528EA"
             },
             {
               "name": "content-length",
@@ -84,7 +85,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 19 Dec 2018 17:12:56 GMT"
+              "value": "Tue, 26 Feb 2019 11:54:21 GMT"
             },
             {
               "name": "via",
@@ -96,7 +97,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-fra19142-FRA"
+              "value": "cache-hhn1520-HHN"
             },
             {
               "name": "x-cache",
@@ -108,7 +109,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1545239576.430149,VS0,VE0"
+              "value": "S1551182061.461877,VS0,VE0"
             },
             {
               "name": "vary",
@@ -120,25 +121,25 @@
             },
             {
               "name": "x-fastly-request-id",
-              "value": "224dc57bd7bb3f4b47e913df5673ffc91b658e8f"
+              "value": "f77fc91d714848ebdd3b853ab36bd4489feff16c"
             },
             {
               "name": "expires",
-              "value": "Wed, 19 Dec 2018 17:17:56 GMT"
+              "value": "Tue, 26 Feb 2019 11:59:21 GMT"
             },
             {
               "name": "source-age",
-              "value": "218"
+              "value": "2"
             }
           ],
-          "headersSize": 798,
+          "headersSize": 815,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2018-12-19T17:12:56.361Z",
-        "time": 116,
+        "startedDateTime": "2019-02-26T11:54:21.401Z",
+        "time": 82,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -146,7 +147,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 116
+          "wait": 82
         }
       }
     ],

--- a/test/fixtures/Testing-XML-Pipeline_1741549992/xmp-pipe-uses-default-logger-if-none-provided_3867768995/recording.har
+++ b/test/fixtures/Testing-XML-Pipeline_1741549992/xmp-pipe-uses-default-logger-if-none-provided_3867768995/recording.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "f6d21213aea4a5155bf5ebb41ef6650e",
+        "_id": "718996af3803e62c740c1b7eef8fb81e",
         "_order": 0,
         "cache": {},
         "request": {
@@ -23,9 +23,6 @@
           "headersSize": 117,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "postData": {
-            "mimeType": "text/plain"
-          },
           "queryString": [],
           "url": "https://raw.githubusercontent.com/trieloff/soupdemo/master/hello.md"
         },
@@ -71,8 +68,12 @@
               "value": "max-age=300"
             },
             {
+              "name": "x-geo-block-list",
+              "value": ""
+            },
+            {
               "name": "x-github-request-id",
-              "value": "1DA8:15DD:368E4F:3C7951:5C1A7B3D"
+              "value": "A784:3615:21A12C:24128E:5C7528EA"
             },
             {
               "name": "content-length",
@@ -84,7 +85,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 19 Dec 2018 17:12:56 GMT"
+              "value": "Tue, 26 Feb 2019 11:54:21 GMT"
             },
             {
               "name": "via",
@@ -96,7 +97,7 @@
             },
             {
               "name": "x-served-by",
-              "value": "cache-fra19123-FRA"
+              "value": "cache-hhn1526-HHN"
             },
             {
               "name": "x-cache",
@@ -108,7 +109,7 @@
             },
             {
               "name": "x-timer",
-              "value": "S1545239577.585858,VS0,VE1"
+              "value": "S1551182062.570176,VS0,VE1"
             },
             {
               "name": "vary",
@@ -120,25 +121,25 @@
             },
             {
               "name": "x-fastly-request-id",
-              "value": "109e8091784714dcfaa3407d23b53c4006f39587"
+              "value": "0d100216845292fe06620113d0bbb38d4a543f14"
             },
             {
               "name": "expires",
-              "value": "Wed, 19 Dec 2018 17:17:56 GMT"
+              "value": "Tue, 26 Feb 2019 11:59:21 GMT"
             },
             {
               "name": "source-age",
-              "value": "219"
+              "value": "2"
             }
           ],
-          "headersSize": 798,
+          "headersSize": 815,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2018-12-19T17:12:56.515Z",
-        "time": 114,
+        "startedDateTime": "2019-02-26T11:54:21.511Z",
+        "time": 81,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -146,7 +147,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 114
+          "wait": 81
         }
       }
     ],

--- a/test/testFetchMarkdown.js
+++ b/test/testFetchMarkdown.js
@@ -294,11 +294,12 @@ describe('Test misbehaved HTTP Responses', () => {
   it('Getting XDM README with ultra-short Timeout', async function shortTimeout() {
     const { server } = this.polly;
 
-    const wait = ms => new Promise(r => setTimeout(r, ms));
-
     server
       .get('https://raw.githubusercontent.com/adobe/xdm/master/README.md')
-      .intercept((_, res) => wait(50).then(res.sendStatus(500)));
+      .intercept(async (_, res) => {
+        await server.timeout(50);
+        res.sendStatus(500);
+      });
 
     const myaction = {
       request: {
@@ -322,11 +323,13 @@ describe('Test misbehaved HTTP Responses', () => {
   it('Getting XDM README with Backend Timeout', async function badTimeout() {
     const { server } = this.polly;
 
-    const wait = ms => new Promise(r => setTimeout(r, ms));
 
     server
       .get('https://raw.githubusercontent.com/adobe/xdm/master/README.md')
-      .intercept((_, res) => wait(2000).then(res.sendStatus(500)));
+      .intercept(async (_, res) => {
+        await server.timeout(2000);
+        res.sendStatus(500);
+      });
 
     const myaction = {
       request: {


### PR DESCRIPTION
Pollyjs broke some compatibility in moving to 2.1.0 (replacing their native implementation with `nock`, therefore #172 and #171 have been failing.

This PR fixes the tests.