### PR TITLE
Section and subitems type is wrong for paragraph with a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ The `types` property is an array of string values that describes the type of the
 
 - `has-<type>`: for each type of content that occurs at least once in the section, e.g. has-heading
 - `is-<type>-only`: for sections that only have content of a single type, e.g. is-image-only
-- `is-<type-1>-<type-2>-<type3>`, `is-<type-1>-<type-2>`, and `is-<type-1>` for the top 3 most frequent types of children in the section. For instance a gallery with a heading and description would be `is-image-paragraph-heading`. You can infer additional types using [`utils.types`](#infer-content-types-with-utilstypes).
+- `is-<type-1>-<type-2>-<type3>`, `is-<type-1>-<type-2>`, and `is-<type-1>` for the top 3 most frequent types of children in the section. For instance a gallery with a heading and description would be `is-image-text-heading`. You can infer additional types using [`utils.types`](#infer-content-types-with-utilstypes).
 - `nb-<type>-<occurences>`: number of occurences of each type in the section
 
 Each section has additional content-derived metadata properties, in particular:
@@ -579,8 +579,8 @@ Step 5 (diff only):
 +        ],
 +        "title": "Hello World",
 +        "types": [
-+          "has-paragraph",
-+          "is-paragraph-only"
++          "has-text",
++          "is-text-only"
 +        ],
 +        "intro": "Hello World",
 +        "meta": {}

--- a/src/html/get-metadata.js
+++ b/src/html/get-metadata.js
@@ -87,13 +87,20 @@ function sectiontype(section) {
     if (type === 'paragraph' && pChildren && pChildren.length > 0) {
       // if child is a paragraph, check its children, it might contain an image or a list
       // which are always wrapped by default.
-      pChildren.forEach(({ type: subType }) => {
-        // exclude text nodes which are default paragraph content
-        if (subType !== 'text') {
-          const mycount = mycounter[subType] || 0;
-          mycounter[subType] = mycount + 1;
-          node.data.types.push(`is-${subType}`);
+      pChildren.forEach((p) => {
+        let prefix = 'has';
+        if (p.type === 'text') {
+          // do not count "empty" paragraphs
+          if (p.value === '\n' || p.value === '') return;
+
+          // paragraph with type text "is" a text
+          prefix = 'is';
         }
+        if (!node.data.types.includes(`${prefix}-${p.type}`)) {
+          node.data.types.push(`${prefix}-${p.type}`);
+        }
+        const mycount = mycounter[p.type] || 0;
+        mycounter[p.type] = mycount + 1;
       });
     }
 

--- a/test/fixtures/sections/2images.json
+++ b/test/fixtures/sections/2images.json
@@ -1,0 +1,42 @@
+[
+  {
+    "title": "helix-logo\nhelix-logo",
+    "types": [
+      "has-image",
+      "nb-image-2",
+      "is-image-only"
+    ],
+    "image": "./helix_logo.png",
+    "intro": "helix-logo\nhelix-logo",
+    "meta": {},
+    "type": "root",
+    "children": [
+      {
+        "type": "paragraph",
+        "children": [
+          {
+            "type": "image",
+            "title": null,
+            "url": "./helix_logo.png",
+            "alt": "helix-logo"
+          },
+          {
+            "type": "text",
+            "value": "\n"
+          },
+          {
+            "type": "image",
+            "title": null,
+            "url": "./helix_logo.png",
+            "alt": "helix-logo"
+          }
+        ],
+        "data": {
+          "types": [
+            "has-image"
+          ]
+        }
+      }
+    ]
+  }
+]

--- a/test/fixtures/sections/2images.md
+++ b/test/fixtures/sections/2images.md
@@ -1,0 +1,2 @@
+![helix-logo](./helix_logo.png)
+![helix-logo](./helix_logo.png)

--- a/test/fixtures/sections/complex.json
+++ b/test/fixtures/sections/complex.json
@@ -2,13 +2,13 @@
   {
     "types": [
       "has-link",
+      "has-text",
       "has-heading",
-      "has-paragraph",
       "nb-link-6",
+      "nb-text-3",
       "nb-heading-2",
-      "nb-paragraph-2",
-      "is-link-heading-paragraph",
-      "is-link-heading",
+      "is-link-text-heading",
+      "is-link-text",
       "is-link"
     ],
     "image": "https://img.shields.io/codecov/c/github/adobe/hypermedia-pipeline.svg",
@@ -51,7 +51,7 @@
         ],
         "data": {
           "types": [
-            "is-paragraph"
+            "is-text"
           ]
         }
       },
@@ -65,7 +65,7 @@
         ],
         "data": {
           "types": [
-            "is-paragraph"
+            "is-text"
           ]
         }
       },
@@ -188,12 +188,8 @@
         ],
         "data": {
           "types": [
-            "is-link",
-            "is-link",
-            "is-link",
-            "is-link",
-            "is-link",
-            "is-link"
+            "has-link",
+            "is-text"
           ]
         }
       }
@@ -201,17 +197,17 @@
   },
   {
     "types": [
+      "has-text",
       "has-inlineCode",
       "has-list",
-      "has-paragraph",
       "has-heading",
+      "nb-text-4",
       "nb-inlineCode-2",
       "nb-list-1",
-      "nb-paragraph-1",
       "nb-heading-1",
-      "is-inlineCode-list-paragraph",
-      "is-inlineCode-list",
-      "is-inlineCode"
+      "is-text-inlineCode-list",
+      "is-text-inlineCode",
+      "is-text"
     ],
     "intro": "A pipeline consists of following main parts:",
     "title": "Anatomy of a Pipeline",
@@ -252,7 +248,7 @@
         ],
         "data": {
           "types": [
-            "is-paragraph"
+            "is-text"
           ]
         }
       },
@@ -277,7 +273,7 @@
                 ],
                 "data": {
                   "types": [
-                    "is-paragraph"
+                    "is-text"
                   ]
                 }
               }
@@ -298,7 +294,7 @@
                 ],
                 "data": {
                   "types": [
-                    "is-paragraph"
+                    "is-text"
                   ]
                 }
               }
@@ -319,7 +315,7 @@
                 ],
                 "data": {
                   "types": [
-                    "is-paragraph"
+                    "is-text"
                   ]
                 }
               }
@@ -340,7 +336,7 @@
                 ],
                 "data": {
                   "types": [
-                    "is-paragraph"
+                    "is-text"
                   ]
                 }
               }
@@ -349,9 +345,9 @@
         ],
         "data": {
           "types": [
-            "has-paragraph",
-            "nb-paragraph-4",
-            "is-paragraph-only",
+            "has-text",
+            "nb-text-4",
+            "is-text-only",
             "is-list"
           ]
         }
@@ -382,8 +378,8 @@
         ],
         "data": {
           "types": [
-            "is-inlineCode",
-            "is-inlineCode"
+            "is-text",
+            "has-inlineCode"
           ]
         }
       }
@@ -392,9 +388,9 @@
   {
     "title": "This section has a paragraph, but no title.",
     "types": [
-      "has-paragraph",
-      "nb-paragraph-2",
-      "is-paragraph-only"
+      "has-text",
+      "nb-text-2",
+      "is-text-only"
     ],
     "intro": "This section has a paragraph, but no title.",
     "meta": {},
@@ -410,7 +406,7 @@
         ],
         "data": {
           "types": [
-            "is-paragraph"
+            "is-text"
           ]
         }
       },
@@ -424,7 +420,7 @@
         ],
         "data": {
           "types": [
-            "is-paragraph"
+            "is-text"
           ]
         }
       }
@@ -462,11 +458,11 @@
     "title": "See below for the anatomy of a payload.",
     "types": [
       "has-list",
-      "has-paragraph",
+      "has-text",
       "nb-list-1",
-      "nb-paragraph-2",
-      "is-paragraph-list",
-      "is-paragraph"
+      "nb-text-2",
+      "is-text-list",
+      "is-text"
     ],
     "intro": "See below for the anatomy of a payload.",
     "meta": {},
@@ -482,7 +478,7 @@
         ],
         "data": {
           "types": [
-            "is-paragraph"
+            "is-text"
           ]
         }
       },
@@ -496,7 +492,7 @@
         ],
         "data": {
           "types": [
-            "is-paragraph"
+            "is-text"
           ]
         }
       },
@@ -533,8 +529,8 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode",
-                    "is-inlineCode"
+                    "has-inlineCode",
+                    "is-text"
                   ]
                 }
               }
@@ -567,8 +563,8 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode",
-                    "is-inlineCode"
+                    "has-inlineCode",
+                    "is-text"
                   ]
                 }
               }
@@ -578,8 +574,11 @@
         "data": {
           "types": [
             "has-inlineCode",
+            "has-text",
             "nb-inlineCode-4",
-            "is-inlineCode-only",
+            "nb-text-4",
+            "is-inlineCode-text",
+            "is-inlineCode",
             "is-list"
           ]
         }
@@ -588,19 +587,19 @@
   },
   {
     "types": [
+      "has-text",
       "has-inlineCode",
       "has-code",
-      "has-paragraph",
       "has-list",
       "has-heading",
+      "nb-text-6",
       "nb-inlineCode-3",
       "nb-code-1",
-      "nb-paragraph-1",
       "nb-list-1",
       "nb-heading-1",
-      "is-inlineCode-code-paragraph",
-      "is-inlineCode-code",
-      "is-inlineCode"
+      "is-text-inlineCode-code",
+      "is-text-inlineCode",
+      "is-text"
     ],
     "intro": "A pipeline builder can be created by creating a CommonJS module that exports a function pipe which accepts following arguments and returns a Pipeline function.",
     "title": "Building a Pipeline",
@@ -649,7 +648,8 @@
         ],
         "data": {
           "types": [
-            "is-inlineCode"
+            "is-text",
+            "has-inlineCode"
           ]
         }
       },
@@ -678,7 +678,8 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode"
+                    "has-inlineCode",
+                    "is-text"
                   ]
                 }
               }
@@ -703,7 +704,8 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode"
+                    "has-inlineCode",
+                    "is-text"
                   ]
                 }
               }
@@ -736,8 +738,8 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode",
-                    "is-inlineCode"
+                    "has-inlineCode",
+                    "is-text"
                   ]
                 }
               }
@@ -777,8 +779,9 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode",
-                    "is-link"
+                    "has-inlineCode",
+                    "is-text",
+                    "has-link"
                   ]
                 }
               }
@@ -788,11 +791,14 @@
         "data": {
           "types": [
             "has-inlineCode",
+            "has-text",
             "has-link",
             "nb-inlineCode-5",
+            "nb-text-6",
             "nb-link-1",
-            "is-inlineCode-link",
-            "is-inlineCode",
+            "is-text-inlineCode-link",
+            "is-text-inlineCode",
+            "is-text",
             "is-list"
           ]
         }
@@ -807,7 +813,7 @@
         ],
         "data": {
           "types": [
-            "is-paragraph"
+            "is-text"
           ]
         }
       },
@@ -848,8 +854,8 @@
         ],
         "data": {
           "types": [
-            "is-inlineCode",
-            "is-inlineCode"
+            "is-text",
+            "has-inlineCode"
           ]
         }
       }
@@ -858,18 +864,18 @@
   {
     "types": [
       "has-list",
+      "has-text",
       "has-inlineCode",
       "has-heading",
-      "has-paragraph",
       "has-code",
       "nb-list-9",
+      "nb-text-25",
       "nb-inlineCode-11",
       "nb-heading-10",
-      "nb-paragraph-9",
       "nb-code-1",
-      "is-inlineCode-heading-list",
-      "is-inlineCode-heading",
-      "is-inlineCode"
+      "is-text-inlineCode-heading",
+      "is-text-inlineCode",
+      "is-text"
     ],
     "intro": "The main function is typically a pure function that converts the request, context, and content properties of the payload into a response object.",
     "title": "The Main Function",
@@ -933,10 +939,8 @@
         ],
         "data": {
           "types": [
-            "is-inlineCode",
-            "is-inlineCode",
-            "is-inlineCode",
-            "is-inlineCode"
+            "is-text",
+            "has-inlineCode"
           ]
         }
       },
@@ -950,7 +954,7 @@
         ],
         "data": {
           "types": [
-            "is-paragraph"
+            "is-text"
           ]
         }
       },
@@ -980,8 +984,8 @@
         ],
         "data": {
           "types": [
-            "is-inlineCode",
-            "is-inlineCode"
+            "is-text",
+            "has-inlineCode"
           ]
         }
       },
@@ -995,7 +999,7 @@
         ],
         "data": {
           "types": [
-            "is-paragraph"
+            "is-text"
           ]
         }
       },
@@ -1032,8 +1036,8 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode",
-                    "is-inlineCode"
+                    "has-inlineCode",
+                    "is-text"
                   ]
                 }
               }
@@ -1066,8 +1070,8 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode",
-                    "is-inlineCode"
+                    "has-inlineCode",
+                    "is-text"
                   ]
                 }
               }
@@ -1092,7 +1096,8 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode"
+                    "has-inlineCode",
+                    "is-text"
                   ]
                 }
               }
@@ -1125,8 +1130,8 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode",
-                    "is-inlineCode"
+                    "has-inlineCode",
+                    "is-text"
                   ]
                 }
               }
@@ -1136,8 +1141,11 @@
         "data": {
           "types": [
             "has-inlineCode",
+            "has-text",
             "nb-inlineCode-7",
-            "is-inlineCode-only",
+            "nb-text-7",
+            "is-inlineCode-text",
+            "is-inlineCode",
             "is-list"
           ]
         }
@@ -1167,7 +1175,7 @@
         ],
         "data": {
           "types": [
-            "is-paragraph"
+            "is-text"
           ]
         }
       },
@@ -1181,7 +1189,7 @@
         ],
         "data": {
           "types": [
-            "is-paragraph"
+            "is-text"
           ]
         }
       },
@@ -1206,7 +1214,7 @@
                 ],
                 "data": {
                   "types": [
-                    "is-paragraph"
+                    "is-text"
                   ]
                 }
               }
@@ -1227,7 +1235,7 @@
                 ],
                 "data": {
                   "types": [
-                    "is-paragraph"
+                    "is-text"
                   ]
                 }
               }
@@ -1248,7 +1256,7 @@
                 ],
                 "data": {
                   "types": [
-                    "is-paragraph"
+                    "is-text"
                   ]
                 }
               }
@@ -1257,9 +1265,9 @@
         ],
         "data": {
           "types": [
-            "has-paragraph",
-            "nb-paragraph-3",
-            "is-paragraph-only",
+            "has-text",
+            "nb-text-3",
+            "is-text-only",
             "is-list"
           ]
         }
@@ -1274,7 +1282,7 @@
         ],
         "data": {
           "types": [
-            "is-paragraph"
+            "is-text"
           ]
         }
       },
@@ -1314,7 +1322,7 @@
         ],
         "data": {
           "types": [
-            "is-paragraph"
+            "is-text"
           ]
         }
       },
@@ -1339,7 +1347,7 @@
                 ],
                 "data": {
                   "types": [
-                    "is-paragraph"
+                    "is-text"
                   ]
                 }
               }
@@ -1360,7 +1368,7 @@
                 ],
                 "data": {
                   "types": [
-                    "is-paragraph"
+                    "is-text"
                   ]
                 }
               }
@@ -1381,7 +1389,7 @@
                 ],
                 "data": {
                   "types": [
-                    "is-paragraph"
+                    "is-text"
                   ]
                 }
               }
@@ -1390,9 +1398,9 @@
         ],
         "data": {
           "types": [
-            "has-paragraph",
-            "nb-paragraph-3",
-            "is-paragraph-only",
+            "has-text",
+            "nb-text-3",
+            "is-text-only",
             "is-list"
           ]
         }
@@ -1422,7 +1430,7 @@
         ],
         "data": {
           "types": [
-            "is-paragraph"
+            "is-text"
           ]
         }
       },
@@ -1447,7 +1455,7 @@
                 ],
                 "data": {
                   "types": [
-                    "is-paragraph"
+                    "is-text"
                   ]
                 }
               }
@@ -1456,9 +1464,9 @@
         ],
         "data": {
           "types": [
-            "has-paragraph",
-            "nb-paragraph-1",
-            "is-paragraph-only",
+            "has-text",
+            "nb-text-1",
+            "is-text-only",
             "is-list"
           ]
         }
@@ -1488,7 +1496,7 @@
         ],
         "data": {
           "types": [
-            "is-paragraph"
+            "is-text"
           ]
         }
       },
@@ -1513,7 +1521,7 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode"
+                    "has-inlineCode"
                   ]
                 }
               }
@@ -1534,7 +1542,7 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode"
+                    "has-inlineCode"
                   ]
                 }
               }
@@ -1555,7 +1563,7 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode"
+                    "has-inlineCode"
                   ]
                 }
               }
@@ -1576,7 +1584,7 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode"
+                    "has-inlineCode"
                   ]
                 }
               }
@@ -1597,7 +1605,7 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode"
+                    "has-inlineCode"
                   ]
                 }
               }
@@ -1661,7 +1669,8 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode"
+                    "has-inlineCode",
+                    "is-text"
                   ]
                 }
               }
@@ -1686,7 +1695,8 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode"
+                    "has-inlineCode",
+                    "is-text"
                   ]
                 }
               }
@@ -1696,8 +1706,11 @@
         "data": {
           "types": [
             "has-inlineCode",
+            "has-text",
             "nb-inlineCode-2",
-            "is-inlineCode-only",
+            "nb-text-2",
+            "is-inlineCode-text",
+            "is-inlineCode",
             "is-list"
           ]
         }
@@ -1754,8 +1767,8 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode",
-                    "is-inlineCode"
+                    "has-inlineCode",
+                    "is-text"
                   ]
                 }
               }
@@ -1791,8 +1804,9 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode",
-                    "is-link"
+                    "has-inlineCode",
+                    "is-text",
+                    "has-link"
                   ]
                 }
               }
@@ -1817,7 +1831,8 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode"
+                    "has-inlineCode",
+                    "is-text"
                   ]
                 }
               },
@@ -1846,7 +1861,8 @@
                         ],
                         "data": {
                           "types": [
-                            "is-inlineCode"
+                            "has-inlineCode",
+                            "is-text"
                           ]
                         }
                       }
@@ -1871,7 +1887,8 @@
                         ],
                         "data": {
                           "types": [
-                            "is-inlineCode"
+                            "has-inlineCode",
+                            "is-text"
                           ]
                         }
                       }
@@ -1896,7 +1913,8 @@
                         ],
                         "data": {
                           "types": [
-                            "is-inlineCode"
+                            "has-inlineCode",
+                            "is-text"
                           ]
                         }
                       }
@@ -1906,8 +1924,11 @@
                 "data": {
                   "types": [
                     "has-inlineCode",
+                    "has-text",
                     "nb-inlineCode-3",
-                    "is-inlineCode-only",
+                    "nb-text-3",
+                    "is-inlineCode-text",
+                    "is-inlineCode",
                     "is-list"
                   ]
                 }
@@ -1933,7 +1954,8 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode"
+                    "has-inlineCode",
+                    "is-text"
                   ]
                 }
               }
@@ -1958,7 +1980,8 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode"
+                    "has-inlineCode",
+                    "is-text"
                   ]
                 }
               }
@@ -1983,7 +2006,8 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode"
+                    "has-inlineCode",
+                    "is-text"
                   ]
                 }
               }
@@ -1993,13 +2017,15 @@
         "data": {
           "types": [
             "has-inlineCode",
+            "has-text",
             "has-list",
             "has-link",
             "nb-inlineCode-7",
+            "nb-text-6",
             "nb-list-1",
             "nb-link-1",
-            "is-inlineCode-list-link",
-            "is-inlineCode-list",
+            "is-inlineCode-text-list",
+            "is-inlineCode-text",
             "is-inlineCode",
             "is-list"
           ]
@@ -2057,8 +2083,8 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode",
-                    "is-inlineCode"
+                    "has-inlineCode",
+                    "is-text"
                   ]
                 }
               }
@@ -2083,7 +2109,8 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode"
+                    "has-inlineCode",
+                    "is-text"
                   ]
                 }
               }
@@ -2108,7 +2135,8 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode"
+                    "has-inlineCode",
+                    "is-text"
                   ]
                 }
               }
@@ -2118,8 +2146,11 @@
         "data": {
           "types": [
             "has-inlineCode",
+            "has-text",
             "nb-inlineCode-4",
-            "is-inlineCode-only",
+            "nb-text-3",
+            "is-inlineCode-text",
+            "is-inlineCode",
             "is-list"
           ]
         }
@@ -2157,7 +2188,7 @@
         ],
         "data": {
           "types": [
-            "is-paragraph"
+            "is-text"
           ]
         }
       },
@@ -2210,8 +2241,8 @@
         ],
         "data": {
           "types": [
-            "is-inlineCode",
-            "is-inlineCode"
+            "is-text",
+            "has-inlineCode"
           ]
         }
       },
@@ -2241,8 +2272,8 @@
         ],
         "data": {
           "types": [
-            "is-inlineCode",
-            "is-inlineCode"
+            "is-text",
+            "has-inlineCode"
           ]
         }
       },
@@ -2264,7 +2295,8 @@
         ],
         "data": {
           "types": [
-            "is-inlineCode"
+            "is-text",
+            "has-inlineCode"
           ]
         }
       },
@@ -2293,7 +2325,8 @@
                 ],
                 "data": {
                   "types": [
-                    "is-inlineCode"
+                    "has-inlineCode",
+                    "is-text"
                   ]
                 }
               }
@@ -2303,8 +2336,11 @@
         "data": {
           "types": [
             "has-inlineCode",
+            "has-text",
             "nb-inlineCode-1",
-            "is-inlineCode-only",
+            "nb-text-1",
+            "is-inlineCode-text",
+            "is-inlineCode",
             "is-list"
           ]
         }

--- a/test/fixtures/sections/headerimage.json
+++ b/test/fixtures/sections/headerimage.json
@@ -41,7 +41,7 @@
         ],
         "data": {
           "types": [
-            "is-image"
+            "has-image"
           ]
         }
       }

--- a/test/fixtures/sections/headerlist.json
+++ b/test/fixtures/sections/headerlist.json
@@ -49,7 +49,7 @@
                 ],
                 "data": {
                   "types": [
-                    "is-paragraph"
+                    "is-text"
                   ]
                 }
               }
@@ -70,7 +70,7 @@
                 ],
                 "data": {
                   "types": [
-                    "is-paragraph"
+                    "is-text"
                   ]
                 }
               }
@@ -91,7 +91,7 @@
                 ],
                 "data": {
                   "types": [
-                    "is-paragraph"
+                    "is-text"
                   ]
                 }
               }
@@ -100,9 +100,9 @@
         ],
         "data": {
           "types": [
-            "has-paragraph",
-            "nb-paragraph-3",
-            "is-paragraph-only",
+            "has-text",
+            "nb-text-3",
+            "is-text-only",
             "is-list"
           ]
         }

--- a/test/fixtures/sections/headerpara2images.json
+++ b/test/fixtures/sections/headerpara2images.json
@@ -2,13 +2,13 @@
   {
     "types": [
       "has-image",
-      "has-paragraph",
+      "has-text",
       "has-heading",
       "nb-image-2",
-      "nb-paragraph-1",
+      "nb-text-1",
       "nb-heading-1",
-      "is-image-paragraph-heading",
-      "is-image-paragraph",
+      "is-image-text-heading",
+      "is-image-text",
       "is-image"
     ],
     "image": "./helix_logo.png",
@@ -42,7 +42,7 @@
         ],
         "data": {
           "types": [
-            "is-paragraph"
+            "is-text"
           ]
         }
       },
@@ -68,8 +68,7 @@
         ],
         "data": {
           "types": [
-            "is-image",
-            "is-image"
+            "has-image"
           ]
         }
       }

--- a/test/fixtures/sections/headerparagraph.json
+++ b/test/fixtures/sections/headerparagraph.json
@@ -1,12 +1,12 @@
 [
   {
     "types": [
-      "has-paragraph",
+      "has-text",
       "has-heading",
-      "nb-paragraph-1",
+      "nb-text-1",
       "nb-heading-1",
-      "is-paragraph-heading",
-      "is-paragraph"
+      "is-text-heading",
+      "is-text"
     ],
     "intro": "This is a paragraph.",
     "title": "Header and one paragraph",
@@ -38,7 +38,7 @@
         ],
         "data": {
           "types": [
-            "is-paragraph"
+            "is-text"
           ]
         }
       }

--- a/test/fixtures/sections/headerparaimage.json
+++ b/test/fixtures/sections/headerparaimage.json
@@ -2,13 +2,13 @@
   {
     "types": [
       "has-image",
-      "has-paragraph",
+      "has-text",
       "has-heading",
       "nb-image-1",
-      "nb-paragraph-1",
+      "nb-text-1",
       "nb-heading-1",
-      "is-image-paragraph-heading",
-      "is-image-paragraph",
+      "is-image-text-heading",
+      "is-image-text",
       "is-image"
     ],
     "image": "./helix_logo.png",
@@ -42,7 +42,7 @@
         ],
         "data": {
           "types": [
-            "is-paragraph"
+            "is-text"
           ]
         }
       },
@@ -58,7 +58,7 @@
         ],
         "data": {
           "types": [
-            "is-image"
+            "has-image"
           ]
         }
       }

--- a/test/fixtures/sections/paragraph.json
+++ b/test/fixtures/sections/paragraph.json
@@ -2,9 +2,9 @@
   {
     "title": "This is only a paragraph.",
     "types": [
-      "has-paragraph",
-      "nb-paragraph-1",
-      "is-paragraph-only"
+      "has-text",
+      "nb-text-1",
+      "is-text-only"
     ],
     "intro": "This is only a paragraph.",
     "meta": {},
@@ -20,7 +20,7 @@
         ],
         "data": {
           "types": [
-            "is-paragraph"
+            "is-text"
           ]
         }
       }

--- a/test/fixtures/sections/paragraphwithlink.json
+++ b/test/fixtures/sections/paragraphwithlink.json
@@ -1,0 +1,48 @@
+[
+  {
+    "title": "This is a paragraph with a link!",
+    "types": [
+      "has-text",
+      "has-link",
+      "nb-text-2",
+      "nb-link-1",
+      "is-text-link",
+      "is-text"
+    ],
+    "intro": "This is a paragraph with a link!",
+    "meta": {},
+    "type": "root",
+    "children": [
+      {
+        "type": "paragraph",
+        "children": [
+          {
+            "type": "text",
+            "value": "This is a paragraph with a "
+          },
+          {
+            "type": "link",
+            "title": null,
+            "url": "/index.html",
+            "children": [
+              {
+                "type": "text",
+                "value": "link"
+              }
+            ]
+          },
+          {
+            "type": "text",
+            "value": "!"
+          }
+        ],
+        "data": {
+          "types": [
+            "is-text",
+            "has-link"
+          ]
+        }
+      }
+    ]
+  }
+]

--- a/test/fixtures/sections/paragraphwithlink.md
+++ b/test/fixtures/sections/paragraphwithlink.md
@@ -1,0 +1,1 @@
+This is a paragraph with a [link](/index.html)!

--- a/test/testGetMetadata.js
+++ b/test/testGetMetadata.js
@@ -30,6 +30,8 @@ function callback(body) {
 const SECTIONS_BLOCS = [
   'header',
   'paragraph',
+  'paragraphwithlink',
+  '2images',
   'headerparagraph',
   'headerlist',
   'headerimage',


### PR DESCRIPTION
PR for #201 

This changes quite some little details on how the types for paragraphs are handled:

* the "paragraph" type disappear: a paragraph (p tag) can be an image only or a link only. The notion of paragraph is biased. Replacing the "paragraph" type by the "text" type makes much more sense: a p can then be a text, image or link and a paragraph can have images, links...
* `has-paragraph` and `is-paragraph` becomes then `has-text` and `is-text`
* manages some edge cases like empty text (line break between 2 images for example would generate a useless text paragraph)

From the issue

```md
This is a paragraph with a [link](/index.html)!
```

will now generate:

* section types: `has-text has-link nb-text-2 nb-link-1 is-text-link is-text`
* paragraph types: `is-text has-link`

This is a backward compatibility breaking change.
