### PR TITLE
Refactor frontmatter support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,12 +30,24 @@ module.exports = {
   'rules': {
     'strict': 0,
 
+    // Allow while (true) infinite loops
+    'no-constant-condition': ["error", { "checkLoops": false }],
+
+    // Forbid multiple statements in one line
+    'max-statements-per-line': ["error", { "max": 1 }],
+
+    // Allow for-of loops
+    'no-restricted-syntax': ['error', 'ForInStatement', 'LabeledStatement', 'WithStatement'],
+
+    // Allow return before else & redundant else statements
+    'no-else-return': 'off',
+
     // allow dangling underscores for 'fields'
     'no-underscore-dangle': ['error', {'allowAfterThis': true}],
 
-    // enforce license header
+    // enforce license header (todo: improve plugin to support patterns for multi-lines)
     'header/header': [2, 'block', ['',
-      { pattern: ' * Copyright \\d{4} Adobe\\. All rights reserved\\.', template: ' * Copyright 2019 Adobe. All rights reserved.'},
+      ' * Copyright 2018 Adobe. All rights reserved.',
       ' * This file is licensed to you under the Apache License, Version 2.0 (the "License");',
       ' * you may not use this file except in compliance with the License. You may obtain a copy',
       ' * of the License at http://www.apache.org/licenses/LICENSE-2.0',

--- a/docs/action.schema.md
+++ b/docs/action.schema.md
@@ -19,12 +19,12 @@ Tracks the OpenWhisk action invocation
 
 # Action Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [debug](#debug) | `object` | Optional  | No | Action (this schema) |
-| [logger](#logger) | `object` | Optional  | No | Action (this schema) |
-| [request](#request) | Raw Request | Optional  | No | Action (this schema) |
-| [secrets](#secrets) | Secrets | Optional  | No | Action (this schema) |
+| Property | Type | Required | Defined by |
+|----------|------|----------|------------|
+| [debug](#debug) | `object` | Optional | Action (this schema) |
+| [logger](#logger) | `object` | Optional | Action (this schema) |
+| [request](#request) | Raw Request | Optional | Action (this schema) |
+| [secrets](#secrets) | Secrets | Optional | Action (this schema) |
 
 ## debug
 

--- a/docs/content.schema.md
+++ b/docs/content.schema.md
@@ -19,19 +19,19 @@ The content as retrieved from the repository and enriched in the pipeline.
 
 # Content Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [body](#body) | `string` | Optional  | No | Content (this schema) |
-| [document](#document) | `object` | Optional  | No | Content (this schema) |
-| [htast](#htast) | `object` | Optional  | No | Content (this schema) |
-| [image](#image) | `string` | Optional  | No | Content (this schema) |
-| [intro](#intro) | `string` | Optional  | No | Content (this schema) |
-| [mdast](#mdast) | MDAST | Optional  | No | Content (this schema) |
-| [meta](#meta) | `object` | Optional  | No | Content (this schema) |
-| [sections](#sections) | Section | Optional  | No | Content (this schema) |
-| [sources](#sources) | `string[]` | Optional  | No | Content (this schema) |
-| [title](#title) | `string` | Optional  | No | Content (this schema) |
-| [xml](#xml) | `object` | Optional  | No | Content (this schema) |
+| Property | Type | Required | Defined by |
+|----------|------|----------|------------|
+| [body](#body) | `string` | Optional | Content (this schema) |
+| [document](#document) | `object` | Optional | Content (this schema) |
+| [htast](#htast) | `object` | Optional | Content (this schema) |
+| [image](#image) | `string` | Optional | Content (this schema) |
+| [intro](#intro) | `string` | Optional | Content (this schema) |
+| [mdast](#mdast) | MDAST | Optional | Content (this schema) |
+| [meta](#meta) | `object` | Optional | Content (this schema) |
+| [sections](#sections) | Section | Optional | Content (this schema) |
+| [sources](#sources) | `string[]` | Optional | Content (this schema) |
+| [title](#title) | `string` | Optional | Content (this schema) |
+| [xml](#xml) | `object` | Optional | Content (this schema) |
 
 ## body
 

--- a/docs/context.schema.md
+++ b/docs/context.schema.md
@@ -20,12 +20,12 @@ The context thingie.
 
 # Context Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [content](#content) | Content | Optional  | No | Context (this schema) |
-| [error](#error) | multiple | Optional  | No | Context (this schema) |
-| [request](#request) | Request | Optional  | No | Context (this schema) |
-| [response](#response) | Response | Optional  | No | Context (this schema) |
+| Property | Type | Required | Defined by |
+|----------|------|----------|------------|
+| [content](#content) | Content | Optional | Context (this schema) |
+| [error](#error) | complex | Optional | Context (this schema) |
+| [request](#request) | Request | Optional | Context (this schema) |
+| [response](#response) | Response | Optional | Context (this schema) |
 
 ## content
 
@@ -53,15 +53,23 @@ When this property is present, all other values can be ignored.
 `error`
 
 * is optional
-* type: multiple
+* type: complex
 * defined in this schema
 
 ### error Type
 
+Unknown type `string,object`.
 
-Either one of:
- * `string`
- * `object`
+```json
+{
+  "type": [
+    "string",
+    "object"
+  ],
+  "description": "An error message that has been generated during pipeline processing.\nWhen this property is present, all other values can be ignored.",
+  "simpletype": "complex"
+}
+```
 
 
 

--- a/docs/mdast.schema.json
+++ b/docs/mdast.schema.json
@@ -93,6 +93,10 @@
             "type": "string",
             "description": "The string value of the node, if it is a terminal node."
         },
+        "payload": {
+            "type": "object",
+            "description": "The payload of a frontmatter/yaml block"
+        },
         "depth": {
             "type": "integer",
             "minimum": 1,

--- a/docs/mdast.schema.md
+++ b/docs/mdast.schema.md
@@ -18,27 +18,28 @@ A node in the Markdown AST
 
 # MDAST Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [align](#align) | `enum[]` | Optional  | No | MDAST (this schema) |
-| [alt](#alt) | `string` | Optional  | Yes | MDAST (this schema) |
-| [checked](#checked) | `boolean` | Optional  | Yes | MDAST (this schema) |
-| [children](#children) | MDAST | Optional  | No | MDAST (this schema) |
-| [data](#data) | `object` | Optional  | No | MDAST (this schema) |
-| [depth](#depth) | `integer` | Optional  | No | MDAST (this schema) |
-| [identifier](#identifier) | `string` | Optional  | No | MDAST (this schema) |
-| [label](#label) | `string` | Optional  | No | MDAST (this schema) |
-| [lang](#lang) | `string` | Optional  | Yes | MDAST (this schema) |
-| [meta](#meta) | `string` | Optional  | Yes | MDAST (this schema) |
-| [ordered](#ordered) | `boolean` | Optional  | No | MDAST (this schema) |
-| [position](#position) | Position | Optional  | No | MDAST (this schema) |
-| [referenceType](#referencetype) | `enum` | Optional  | No | MDAST (this schema) |
-| [spread](#spread) | `boolean` | Optional  | Yes | MDAST (this schema) |
-| [start](#start) | `integer` | Optional  | Yes | MDAST (this schema) |
-| [title](#title) | `string` | Optional  | Yes | MDAST (this schema) |
-| [type](#type) | `enum` | Optional  | No | MDAST (this schema) |
-| [url](#url) | `string` | Optional  | No | MDAST (this schema) |
-| [value](#value) | `string` | Optional  | No | MDAST (this schema) |
+| Property | Type | Required | Defined by |
+|----------|------|----------|------------|
+| [align](#align) | `enum[]` | Optional | MDAST (this schema) |
+| [alt](#alt) | complex | Optional | MDAST (this schema) |
+| [checked](#checked) | complex | Optional | MDAST (this schema) |
+| [children](#children) | MDAST | Optional | MDAST (this schema) |
+| [data](#data) | `object` | Optional | MDAST (this schema) |
+| [depth](#depth) | `integer` | Optional | MDAST (this schema) |
+| [identifier](#identifier) | `string` | Optional | MDAST (this schema) |
+| [label](#label) | `string` | Optional | MDAST (this schema) |
+| [lang](#lang) | complex | Optional | MDAST (this schema) |
+| [meta](#meta) | complex | Optional | MDAST (this schema) |
+| [ordered](#ordered) | `boolean` | Optional | MDAST (this schema) |
+| [payload](#payload) | `object` | Optional | MDAST (this schema) |
+| [position](#position) | Position | Optional | MDAST (this schema) |
+| [referenceType](#referencetype) | `enum` | Optional | MDAST (this schema) |
+| [spread](#spread) | complex | Optional | MDAST (this schema) |
+| [start](#start) | complex | Optional | MDAST (this schema) |
+| [title](#title) | complex | Optional | MDAST (this schema) |
+| [type](#type) | `enum` | Optional | MDAST (this schema) |
+| [url](#url) | `string` | Optional | MDAST (this schema) |
+| [value](#value) | `string` | Optional | MDAST (this schema) |
 
 ## align
 
@@ -74,15 +75,23 @@ An alt field should be present. It represents equivalent content for environment
 `alt`
 
 * is optional
-* type: `string`
+* type: complex
 * defined in this schema
 
 ### alt Type
 
+Unknown type `string,null`.
 
-`string`, nullable
-
-
+```json
+{
+  "type": [
+    "string",
+    "null"
+  ],
+  "description": "An alt field should be present. It represents equivalent content for environments that cannot represent the node as intended.",
+  "simpletype": "complex"
+}
+```
 
 
 
@@ -95,13 +104,23 @@ A checked field can be present. It represents whether the item is done (when tru
 `checked`
 
 * is optional
-* type: `boolean`
+* type: complex
 * defined in this schema
 
 ### checked Type
 
+Unknown type `null,boolean`.
 
-`boolean`, nullable
+```json
+{
+  "type": [
+    "null",
+    "boolean"
+  ],
+  "description": "A checked field can be present. It represents whether the item is done (when true), not done (when false), or indeterminate or not applicable (when null or not present).",
+  "simpletype": "complex"
+}
+```
 
 
 
@@ -226,15 +245,23 @@ For code, a lang field can be present. It represents the language of computer co
 `lang`
 
 * is optional
-* type: `string`
+* type: complex
 * defined in this schema
 
 ### lang Type
 
+Unknown type `null,string`.
 
-`string`, nullable
-
-
+```json
+{
+  "type": [
+    "null",
+    "string"
+  ],
+  "description": "For code, a lang field can be present. It represents the language of computer code being marked up.",
+  "simpletype": "complex"
+}
+```
 
 
 
@@ -247,15 +274,23 @@ For code, if lang is present, a meta field can be present. It represents custom 
 `meta`
 
 * is optional
-* type: `string`
+* type: complex
 * defined in this schema
 
 ### meta Type
 
+Unknown type `null,string`.
 
-`string`, nullable
-
-
+```json
+{
+  "type": [
+    "null",
+    "string"
+  ],
+  "description": "For code, if lang is present, a meta field can be present. It represents custom information relating to the node.",
+  "simpletype": "complex"
+}
+```
 
 
 
@@ -275,6 +310,30 @@ Is the list ordered
 
 
 `boolean`
+
+
+
+
+
+## payload
+
+The payload of a frontmatter/yaml block
+
+`payload`
+
+* is optional
+* type: `object`
+* defined in this schema
+
+### payload Type
+
+
+`object` with following properties:
+
+
+| Property | Type | Required |
+|----------|------|----------|
+
 
 
 
@@ -327,13 +386,23 @@ A spread field can be present. It represents that any of its items is separated 
 `spread`
 
 * is optional
-* type: `boolean`
+* type: complex
 * defined in this schema
 
 ### spread Type
 
+Unknown type `null,boolean`.
 
-`boolean`, nullable
+```json
+{
+  "type": [
+    "null",
+    "boolean"
+  ],
+  "description": "A spread field can be present. It represents that any of its items is separated by a blank line from its siblings or contains two or more children (when true), or not (when false or not present).",
+  "simpletype": "complex"
+}
+```
 
 
 
@@ -346,15 +415,23 @@ Starting item of the list
 `start`
 
 * is optional
-* type: `integer`
+* type: complex
 * defined in this schema
 
 ### start Type
 
+Unknown type `null,integer`.
 
-`integer`, nullable
-
-
+```json
+{
+  "type": [
+    "null",
+    "integer"
+  ],
+  "description": "Starting item of the list",
+  "simpletype": "complex"
+}
+```
 
 
 
@@ -367,15 +444,23 @@ For resources, a title field can be present. It represents advisory information 
 `title`
 
 * is optional
-* type: `string`
+* type: complex
 * defined in this schema
 
 ### title Type
 
+Unknown type `string,null`.
 
-`string`, nullable
-
-
+```json
+{
+  "type": [
+    "string",
+    "null"
+  ],
+  "description": "For resources, a title field can be present. It represents advisory information for the resource, such as would be appropriate for a tooltip.",
+  "simpletype": "complex"
+}
+```
 
 
 

--- a/docs/position.schema.md
+++ b/docs/position.schema.md
@@ -18,11 +18,11 @@ Marks the position of an AST node in the original text flow
 
 # Position Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [end](#end) | Text Coordinates | Optional  | No | Position (this schema) |
-| [indent](#indent) | `array` | Optional  | No | Position (this schema) |
-| [start](#start) | Text Coordinates | Optional  | No | Position (this schema) |
+| Property | Type | Required | Defined by |
+|----------|------|----------|------------|
+| [end](#end) | Text Coordinates | Optional | Position (this schema) |
+| [indent](#indent) | `array` | Optional | Position (this schema) |
+| [start](#start) | Text Coordinates | Optional | Position (this schema) |
 
 ## end
 

--- a/docs/rawrequest.schema.md
+++ b/docs/rawrequest.schema.md
@@ -13,12 +13,12 @@ The Request Object used for Invoking OpenWhisk
 
 # Raw Request Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [headers](#headers) | `object` | Optional  | No | Raw Request (this schema) |
-| [method](#method) | `string` | Optional  | No | Raw Request (this schema) |
-| [params](#params) | `object` | Optional  | No | Raw Request (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property | Type | Required | Defined by |
+|----------|------|----------|------------|
+| [headers](#headers) | `object` | Optional | Raw Request (this schema) |
+| [method](#method) | `string` | Optional | Raw Request (this schema) |
+| [params](#params) | `object` | Optional | Raw Request (this schema) |
+| `*` | any | Additional | this schema *allows* additional properties |
 
 ## headers
 
@@ -209,13 +209,15 @@ Deprecated: The original OpenWhisk request headers
 
 ##### __ow_headers Type
 
+Unknown type `object`.
 
-`object` with following properties:
-
-
-| Property | Type | Required |
-|----------|------|----------|
-
+```json
+{
+  "type": "object",
+  "description": "Deprecated: The original OpenWhisk request headers",
+  "simpletype": "`object`"
+}
+```
 
 
 
@@ -368,14 +370,4 @@ The resolved strain (variant)
 
 
 
-
-
-
-**All** of the following *requirements* need to be fulfilled.
-
-
-#### Requirement 1
-
-
-* []() – `#/definitions/rawrequest`
 

--- a/docs/request.schema.md
+++ b/docs/request.schema.md
@@ -13,15 +13,15 @@ The HTTP Request
 
 # Request Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [extension](#extension) | `string` | Optional  | No | Request (this schema) |
-| [headers](#headers) | complex | Optional  | No | Request (this schema) |
-| [method](#method) | `string` | Optional  | No | Request (this schema) |
-| [params](#params) | `object` | Optional  | No | Request (this schema) |
-| [path](#path) | `string` | Optional  | No | Request (this schema) |
-| [selector](#selector) | `string` | Optional  | No | Request (this schema) |
-| [url](#url) | `string` | Optional  | No | Request (this schema) |
+| Property | Type | Required | Defined by |
+|----------|------|----------|------------|
+| [extension](#extension) | `string` | Optional | Request (this schema) |
+| [headers](#headers) | complex | Optional | Request (this schema) |
+| [method](#method) | `string` | Optional | Request (this schema) |
+| [params](#params) | `object` | Optional | Request (this schema) |
+| [path](#path) | `string` | Optional | Request (this schema) |
+| [selector](#selector) | `string` | Optional | Request (this schema) |
+| [url](#url) | `string` | Optional | Request (this schema) |
 
 ## extension
 

--- a/docs/response.schema.md
+++ b/docs/response.schema.md
@@ -13,11 +13,11 @@ The HTTP response object
 
 # Response Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [body](#body) | complex | Optional  | No | Response (this schema) |
-| [headers](#headers) | complex | Optional  | No | Response (this schema) |
-| [status](#status) | `integer` | Optional  | No | Response (this schema) |
+| Property | Type | Required | Defined by |
+|----------|------|----------|------------|
+| [body](#body) | complex | Optional | Response (this schema) |
+| [headers](#headers) | complex | Optional | Response (this schema) |
+| [status](#status) | `integer` | Optional | Response (this schema) |
 
 ## body
 
@@ -39,13 +39,6 @@ The HTTP response object
 
 
 #### Option 2
-
-
-`object` with following properties:
-
-
-| Property | Type | Required |
-|----------|------|----------|
 
 
 

--- a/docs/secrets.schema.md
+++ b/docs/secrets.schema.md
@@ -13,20 +13,20 @@ Secrets passed into the pipeline such as API Keys or configuration settings.
 
 # Secrets Properties
 
-| Property | Type | Required | Nullable | Default | Defined by |
-|----------|------|----------|----------|---------|------------|
-| [EMBED_SERVICE](#embed_service) | `string` | Optional  | No | `"https://adobeioruntime.net/api/v1/web/helix/default/embed/"` | Secrets (this schema) |
-| [EMBED_WHITELIST](#embed_whitelist) | `string` | Optional  | No | `"www.youtube.com, spark.adobe.com, unsplash.com/photos"` | Secrets (this schema) |
-| [HTTP_TIMEOUT](#http_timeout) | `integer` | Optional  | No | `1000` | Secrets (this schema) |
-| [IMAGES_MAX_SIZE](#images_max_size) | `integer` | Optional  | No | `4096` | Secrets (this schema) |
-| [IMAGES_MIN_SIZE](#images_min_size) | `integer` | Optional  | No | `480` | Secrets (this schema) |
-| [IMAGES_SIZES](#images_sizes) | `string` | Optional  | No | `"100vw"` | Secrets (this schema) |
-| [IMAGES_SIZE_STEPS](#images_size_steps) | `integer` | Optional  | No | `4` | Secrets (this schema) |
-| [REPO_API_ROOT](#repo_api_root) | `string` | Optional  | No | `"https://api.github.com/"` | Secrets (this schema) |
-| [REPO_RAW_ROOT](#repo_raw_root) | `string` | Optional  | No | `"https://raw.githubusercontent.com/"` | Secrets (this schema) |
-| [TEST_BOOLEAN](#test_boolean) | `boolean` | Optional  | No | `true` | Secrets (this schema) |
-| [XML_PRETTY](#xml_pretty) | `boolean` | Optional  | No | `true` | Secrets (this schema) |
-| `[A-Z0-9_]+` | multiple | Pattern | No |  | Secrets (this schema) |
+| Property | Type | Required | Default | Defined by |
+|----------|------|----------|---------|------------|
+| [EMBED_SERVICE](#embed_service) | `string` | Optional | `"https://adobeioruntime.net/api/v1/web/helix/default/embed/"` | Secrets (this schema) |
+| [EMBED_WHITELIST](#embed_whitelist) | `string` | Optional | `"www.youtube.com, spark.adobe.com, unsplash.com/photos"` | Secrets (this schema) |
+| [HTTP_TIMEOUT](#http_timeout) | `integer` | Optional | `1000` | Secrets (this schema) |
+| [IMAGES_MAX_SIZE](#images_max_size) | `integer` | Optional | `4096` | Secrets (this schema) |
+| [IMAGES_MIN_SIZE](#images_min_size) | `integer` | Optional | `480` | Secrets (this schema) |
+| [IMAGES_SIZES](#images_sizes) | `string` | Optional | `"100vw"` | Secrets (this schema) |
+| [IMAGES_SIZE_STEPS](#images_size_steps) | `integer` | Optional | `4` | Secrets (this schema) |
+| [REPO_API_ROOT](#repo_api_root) | `string` | Optional | `"https://api.github.com/"` | Secrets (this schema) |
+| [REPO_RAW_ROOT](#repo_raw_root) | `string` | Optional | `"https://raw.githubusercontent.com/"` | Secrets (this schema) |
+| [TEST_BOOLEAN](#test_boolean) | `boolean` | Optional | `true` | Secrets (this schema) |
+| [XML_PRETTY](#xml_pretty) | `boolean` | Optional | `true` | Secrets (this schema) |
+| `[A-Z0-9_]+` | complex | Pattern |  | Secrets (this schema) |
 
 ## EMBED_SERVICE
 
@@ -274,7 +274,7 @@ Applies to all properties that match the regular expression `[A-Z0-9_]+`
 `[A-Z0-9_]+`
 
 * is a property pattern
-* type: multiple
+* type: complex
 * defined in this schema
 
 ### Pattern [A-Z0-9_]+ Type
@@ -289,7 +289,7 @@ Unknown type `boolean,integer,number,string`.
     "number",
     "string"
   ],
-  "simpletype": "multiple"
+  "simpletype": "complex"
 }
 ```
 

--- a/docs/section.schema.md
+++ b/docs/section.schema.md
@@ -19,17 +19,17 @@ A section in a markdown document
 
 # Section Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [children](#children) | MDAST | Optional  | No | Section (this schema) |
-| [image](#image) | `string` | Optional  | No | [Meta](meta.schema.md#image) |
-| [intro](#intro) | `string` | Optional  | No | [Meta](meta.schema.md#intro) |
-| [meta](#meta) | `object` | Optional  | No | [Meta](meta.schema.md#meta) |
-| [position](#position) | Position | Optional  | No | Section (this schema) |
-| [title](#title) | `string` | Optional  | No | [Meta](meta.schema.md#title) |
-| [type](#type) | `const` | Optional  | No | Section (this schema) |
-| [types](#types) | `string[]` | Optional  | No | Section (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property | Type | Required | Defined by |
+|----------|------|----------|------------|
+| [children](#children) | MDAST | Optional | Section (this schema) |
+| [image](#image) | `string` | Optional | [Meta](meta.schema.md#image) |
+| [intro](#intro) | `string` | Optional | [Meta](meta.schema.md#intro) |
+| [meta](#meta) | `object` | Optional | [Meta](meta.schema.md#meta) |
+| [position](#position) | Position | Optional | Section (this schema) |
+| [title](#title) | `string` | Optional | [Meta](meta.schema.md#title) |
+| [type](#type) | `const` | Optional | Section (this schema) |
+| [types](#types) | `string[]` | Optional | Section (this schema) |
+| `*` | any | Additional | this schema *allows* additional properties |
 
 ## children
 
@@ -207,20 +207,4 @@ All items must be of the type:
 
 
 
-
-
-
-**All** of the following *requirements* need to be fulfilled.
-
-
-#### Requirement 1
-
-
-* []() – `#/definitions/section`
-
-
-#### Requirement 2
-
-
-* []() – `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta`
 

--- a/docs/textcoordinates.schema.md
+++ b/docs/textcoordinates.schema.md
@@ -13,11 +13,11 @@ A position in a text document
 
 # Text Coordinates Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [column](#column) | `number` | Optional  | No | Text Coordinates (this schema) |
-| [line](#line) | `number` | Optional  | No | Text Coordinates (this schema) |
-| [offset](#offset) | `number` | Optional  | No | Text Coordinates (this schema) |
+| Property | Type | Required | Defined by |
+|----------|------|----------|------------|
+| [column](#column) | `number` | Optional | Text Coordinates (this schema) |
+| [line](#line) | `number` | Optional | Text Coordinates (this schema) |
+| [offset](#offset) | `number` | Optional | Text Coordinates (this schema) |
 
 ## column
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3846,14 +3846,6 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
       "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
     },
-    "fault": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.2.tgz",
-      "integrity": "sha512-o2eo/X2syzzERAtN5LcGbiVQ0WwZSlN3qLtadwAz3X8Bu+XWD16dja/KMsjZLiQr+BLGPDnHGkc4yUJf1Xpkpw==",
-      "requires": {
-        "format": "^0.2.2"
-      }
-    },
     "fecha": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
@@ -4131,11 +4123,6 @@
         "combined-stream": "1.0.6",
         "mime-types": "^2.1.12"
       }
-    },
-    "format": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
-      "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
     },
     "format-util": {
       "version": "1.0.3",
@@ -12352,15 +12339,6 @@
       "requires": {
         "hast-util-from-parse5": "^5.0.0",
         "parse5": "^5.0.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "remark-frontmatter": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.3.0.tgz",
-      "integrity": "sha512-IUE/T91prnrs2law1DlSLJ9I2vSM+YkfcPfBId8OMvzjZh2sTt0lQVxtsQaY7TcA92TDOApQhCXKgfemz0l5dw==",
-      "requires": {
-        "fault": "^1.0.1",
         "xtend": "^4.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "micromatch": "^3.1.10",
     "object-hash": "^1.3.1",
     "rehype-parse": "^6.0.0",
-    "remark-frontmatter": "^1.3.0",
     "remark-parse": "^6.0.0",
     "remark-rehype": "^4.0.0",
     "request": "^2.87.0",

--- a/src/context.d.ts
+++ b/src/context.d.ts
@@ -222,6 +222,12 @@ export interface MDAST {
    */
   value?: string;
   /**
+   * The payload of a frontmatter/yaml block
+   */
+  payload?: {
+    [k: string]: any;
+  };
+  /**
    * The heading level
    */
   depth?: number;
@@ -273,6 +279,16 @@ export interface MDAST {
    * An alt field should be present. It represents equivalent content for environments that cannot represent the node as intended.
    */
   alt?: string | null;
+  /**
+   * Represents the explicitness of a reference.
+   */
+  referenceType?: "shortcut" | "collapsed" | "full";
+  /**
+   * data is guaranteed to never be specified by unist or specifications implementing unist. Free data space.
+   */
+  data?: {
+    [k: string]: any;
+  };
 }
 /**
  * Marks the position of an AST node in the original text flow

--- a/src/defaults/html.pipe.js
+++ b/src/defaults/html.pipe.js
@@ -30,6 +30,7 @@ const dump = require('../utils/dump-context.js');
 const validate = require('../utils/validate');
 const { cache, uncached } = require('../html/shared-cache');
 const embeds = require('../html/find-embeds');
+const parseFrontmatter = require('../html/parse-frontmatter');
 
 /* eslint no-param-reassign: off */
 /* eslint newline-per-chained-call: off */
@@ -47,6 +48,7 @@ const htmlpipe = (cont, payload, action) => {
     .every(validate).when(() => !production())
     .before(fetch).expose('fetch').when(hascontent)
     .before(parse).expose('parse')
+    .before(parseFrontmatter)
     .before(embeds)
     .before(smartypants)
     .before(sections)

--- a/src/defaults/json.pipe.js
+++ b/src/defaults/json.pipe.js
@@ -21,6 +21,7 @@ const sections = require('../html/split-sections');
 const production = require('../utils/is-production');
 const dump = require('../utils/dump-context.js');
 const validate = require('../utils/validate');
+const parseFrontmatter = require('../html/parse-frontmatter');
 
 /* eslint no-param-reassign: off */
 
@@ -33,6 +34,7 @@ const htmlpipe = (cont, payload, action) => {
     .every(validate).when(() => !production())
     .before(fetch)
     .before(parse)
+    .before(parseFrontmatter)
     .before(smartypants)
     .before(sections)
     .before(meta)

--- a/src/defaults/xml.pipe.js
+++ b/src/defaults/xml.pipe.js
@@ -27,6 +27,7 @@ const type = require('../utils/set-content-type.js');
 const emit = require('../xml/emit-xml.js');
 const status = require('../xml/set-xml-status.js');
 const check = require('../xml/check-xml');
+const parseFrontmatter = require('../html/parse-frontmatter');
 
 /* eslint no-param-reassign: off */
 
@@ -39,6 +40,7 @@ const xmlpipe = (cont, payload, action) => {
     .every(validate).when(() => !production())
     .before(fetch)
     .before(parse)
+    .before(parseFrontmatter)
     .before(smartypants)
     .before(sections)
     .before(meta)

--- a/src/html/fetch-markdown.js
+++ b/src/html/fetch-markdown.js
@@ -98,7 +98,7 @@ async function fetch(
   } catch (e) {
     if (e && e.statusCode && e.statusCode === 404) {
       return bail(logger, `Could not find Markdown at ${options.uri}`, e, 404);
-    } if ((e && e.response && e.response.elapsedTime && e.response.elapsedTime > timeout) || (e && e.cause && e.cause.code && (e.cause.code === 'ESOCKETTIMEDOUT' || e.cause.code === 'ETIMEDOUT'))) {
+    } else if ((e && e.response && e.response.elapsedTime && e.response.elapsedTime > timeout) || (e && e.cause && e.cause.code && (e.cause.code === 'ESOCKETTIMEDOUT' || e.cause.code === 'ETIMEDOUT'))) {
       // return gateway timeout
       return bail(logger, `Gateway timout of ${timeout} milliseconds exceeded for ${options.uri}`, e, 504);
     }

--- a/src/html/get-metadata.js
+++ b/src/html/get-metadata.js
@@ -136,7 +136,7 @@ function sectiontype(section) {
 function fallback(section) {
   if (section.intro && !section.title) {
     return Object.assign({ title: section.intro }, section);
-  } if (section.title && !section.intro) {
+  } else if (section.title && !section.intro) {
     return Object.assign({ intro: section.title }, section);
   }
   return section;

--- a/src/html/get-metadata.js
+++ b/src/html/get-metadata.js
@@ -11,12 +11,14 @@
  */
 const { select, selectAll } = require('unist-util-select');
 const plain = require('mdast-util-to-string');
-const { safeLoad } = require('js-yaml');
+const { flat, obj, map } = require('@adobe/helix-shared').sequence;
+
 
 function yaml(section) {
-  const yamls = selectAll('yaml', section); // select all YAML nodes
-  const mapped = yamls.map(({ value }) => safeLoad(value));
-  return Object.assign({ meta: Object.assign({}, ...mapped) }, section);
+  const yamls = selectAll('yaml', section);
+  /* eslint-disable-next-line no-param-reassign */
+  section.meta = obj(flat(map(yamls, ({ payload }) => payload)));
+  return section;
 }
 
 function title(section) {

--- a/src/html/parse-frontmatter.js
+++ b/src/html/parse-frontmatter.js
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+const yaml = require('js-yaml');
+const { cloneDeep } = require('lodash');
+const {
+  join, map, zipLeast2, pipe, list, lookahead, filter, enumerate,
+  identity, range, size, type, reject,
+} = require('@adobe/helix-shared').sequence;
+
+const { assign } = Object;
+
+/**
+ * Given an mdast tree and it's text representation, this finds all
+ * the frontmatter in it.
+ *
+ * Frontmatter looks like this:
+ *
+ * ```
+ * ---
+ * Foo: bar
+ * ---
+ * ```
+ *
+ * The frontmatter is delimited by a `thematicBreak` made from three
+ * dashes in the mdast and contains a yaml-encoded payload.
+ *
+ * Not any yaml and any thematicBreak is accepted; in order to avoid
+ * false positives, the following restrictions apply:
+ *
+ * - There must be the start or end of the document or an empty line (`\n\n`)
+ *   before and after the frontmatter block
+ * - There may be no empty line within the frontmatter block; not even lines
+ *   containing only whitespace
+ * - The yaml must yield an object (as in key-value pairs); strings, numbers or
+ *   arrays are not considered to be frontmatter in this context
+ * - The thematic break must be made up of three dashes
+ *
+ * Note that most of the information required to asses these properties
+ * is not contained in the mdast itself, which is why this algorithm requires
+ * access to the original markdown string. (The mdast is an Abstract Syntax Tree,
+ * the proper tool for a task like this would be a Concrete Syntax Tree, but we have
+ * no such thing...).
+ *
+ * Note that converting the mdast to a markdown string will not do, since
+ * the generated markdown will be much different.
+ *
+ * # Future directions
+ *
+ * This function is likely to change in the following ways:
+ *
+ * - Relaxed restrictions on what constitutes frontmatter.
+ * - The ability to specify custom formats; by specifying the name
+ *   of the format explicitly we reduce ambiguity to pretty much zero
+ *   and can allow for far more complex frontmatter formats.
+ *
+ *    ```
+ *    ---json
+ *    {"foo": 42}
+ *    ---
+ *    ```
+ *
+ * # Ambiguous Frontmatter
+ *
+ * Normally, when one of the conditions above is triggered,
+ * (e.g. Frontmatter containing an empty line; not being an array
+ * instead of an object), a warning will be emitted instead of the
+ * frontmatter being actually parsed & returned.
+ * This warning may be processed by the caller in any way; e.g. by
+ * printing a warning on the console or by throwing an error...
+ *
+ * In order to avoid ambiguous cases, the format described above
+ * should be used for valid frontmatter; in order to use horizontal
+ * rules unambiguously, the markdown author should either use symbols
+ * other than dash to mark horizontal rules, or leave at least one empty
+ * line before and after the three dashes.
+ *
+ * Both ways are guaranteed to be interpreted as horizontal rules and
+ * never yield warnings.
+ *
+ * @param {Mdast} The object containing the mdast, including the root node and position information!
+ * @param {Source} The original markdown
+ * @returns {Iterable} Returns an iterable where each element represents either a
+ *   block frontmatter or a warning issued.
+ *   The order of warnings/frontmatter blocks is the same as in the input document.
+ *
+ *   Blocks of frontmatter use the following format:
+ *
+ *   ```
+ *   {
+ *     type: 'frontmatter',
+ *     payload: {...},
+ *     start: Number,
+ *     end: Number
+ *   }
+ *   ```
+ *
+ *   `start` and `end` represent the index of the mdast node
+ *   node that starts/ends the frontmatter block.
+ *   Just replace all those nodes with an appropriate frontmatter
+ *   node containing the payload to actually insert the frontmatter
+ *   into the yaml.
+ *
+ *   Note that the `mdast` block does not necessarily contain
+ *   only mdast blocks; settext headers for instance require
+ *   us in some cases to
+ *
+ *   Warnings use the following format:
+ *
+ *   ```
+ *   {
+ *     type: 'warning',
+ *     warning: String,
+ *     source: String, // Source code of the frontmatter block
+ *     start: Number, // Node index as in 'frontmatter' type
+ *     end: Number, // May be null if the fence is the last in the markdown
+ *     cause: Error, // The error that caused the problem if any
+ *   }
+ *   ```
+ */
+const findFrontmatter = (mdast, str) => {
+  // We do a lot of stuff with regexps here
+  const hspace = '[^\\S\\n\\r]'; // Horizontal space
+  const re = x => new RegExp(x);
+
+  // Access the markdown source of a markdown ast element
+  const start = idx => mdast.children[idx].position.start.offset;
+  const end = idx => mdast.children[idx].position.end.offset;
+  const nodeStr = idx => str.slice(start(idx), end(idx));
+
+  // Identifying MDAST nodes which are potential fences (but later
+  // still need to be checked more thoroughly)
+  const isHead2 = n => n.type === 'heading' && n.depth === 2;
+  const isHr = n => n.type === 'thematicBreak';
+  const isPotential = n => isHead2(n) || isHr(n);
+
+  // Classifiers for fences: Lets us distinguish actual fences
+  // from headers and horizontal rules which should not be altered:
+  const decentHead = n => n.after && isHead2(n.nod);
+  const decentHr = n => n.after && n.before;
+  const toIgnore = n => !n || decentHead(n) || decentHr(n);
+
+  const procwarnigns = map(([fst, last]) => {
+    const src = str.slice(fst.offStart, last === null ? undefined : last.offEnd);
+
+    const warn = (cause, prosa) => ({
+      type: 'warning',
+      warning: prosa,
+      source: src,
+      fst,
+      last,
+      start: fst.idx,
+      end: last && last.idx,
+      cause,
+    });
+
+    if (!fst.before) {
+      return warn(null,
+        'Found ambigous frontmatter fence: No empty line before the block! '
+          + 'Make sure your frontmatter blocks contain no empty lines '
+          + 'and your horizontal rules have an empty line before AND after them.');
+    } else if (last === null) {
+      return null;
+    } else if (!last.after) {
+      return warn(null,
+        'Found ambigous frontmatter fence: No empty line after the block! '
+          + 'Make sure your frontmatter blocks contain no empty lines '
+          + 'and your horizontal rules have an empty line before AND after them.');
+    } else if (src.match(re(`\\n${hspace}*\\n`))) {
+      return warn(null,
+        'Found ambigous frontmatter fence: Block contains empty line! '
+          + 'Make sure your frontmatter blocks contain no empty lines '
+          + 'and your horizontal rules have an empty line before AND after them.');
+    }
+
+    const txt = str.slice(fst.offEnd, last.offStart);
+    let data;
+    try {
+      data = yaml.safeLoad(txt);
+    } catch (e) {
+      return warn(e, `Exception ocurred while parsing yaml: ${e}`);
+    }
+
+    if (type(data) !== Object) {
+      return warn(null,
+        'Found ambigous frontmatter block: Block contains valid yaml, but '
+          + `it's data type is ${type(data)} instead of Object.`
+          + 'Make sure your yaml blocks contain only key-value pairs at the root level!');
+    }
+
+    return {
+      type: 'frontmatter',
+      payload: data,
+      start: fst.idx,
+      end: last.idx,
+    };
+  });
+
+  // Preprocessing
+  return pipe(
+    enumerate(mdast.children),
+    // Find any potential frontmatter starts/ends in the mdast
+    /* eslint-disable-next-line no-unused-vars */
+    filter(([idx, nod]) => isPotential(nod)),
+    // Filter out dom nodes based on their actual text content;
+    // this filters out HRs made from other characters or setext
+    // headings with more than three dashes...
+    //
+    // And: Perform some more sophisticated feature extraction on the nodes
+    map(([idx, nod]) => {
+      const mat = nodeStr(idx).match(re(`(?<=^|\\n)---${hspace}*\\n?$`));
+      if (!mat) {
+        return null;
+      }
+      // Offset of the actual separator line (this may deviate from the)
+      const offStart = mat.index + start(idx);
+      const offEnd = offStart + size(mat[0]);
+      // Is there a new line or EOF before/after the separator?
+      const before = Boolean(str.slice(0, offStart).match(re(`(^|(^|\\n)${hspace}*\\n)$`)));
+      const after = Boolean(str.slice(offEnd).match(re(`^(${hspace}*(\\n${hspace}*(\\n|$))|$)`)));
+      return {
+        idx, nod, offStart, offEnd, before, after,
+      };
+    }),
+    filter(identity),
+    // Pair up two fences each; we even do this if there is only a single
+    // fence (even though by definition that could never form a frontmatter
+    // block) in order to warn about ambiguous nodes
+    lookahead(1, null),
+    // Filter out pairs in which both the start and the end is definately
+    // a settext heading or <hr>
+    reject(([fst, last]) => toIgnore(fst) && toIgnore(last)),
+    // Decide which blocks to ignore, which deserve warnings and which
+    // are actual frontmatter
+    procwarnigns,
+    filter(identity),
+    // Filter out false positive warnings for pseudo frontmatter blocks
+    // before actual frontmatter (warning gets invalidated by the fact
+    // that it DIRECTLY PRECEDES an actual frontmatter block)
+    lookahead(1, null),
+    reject(([val, next]) => true
+      && val.type === 'warning'
+      && val.warning.startsWith('Found ambigous frontmatter')
+      && next
+      && next.type === 'frontmatter'
+      && val.end === next.start),
+    /* eslint-disable-next-line no-unused-vars */
+    map(([val, next]) => val),
+  );
+};
+
+class FrontmatterParsingError extends Error {}
+
+const parseFrontmatter = ({ content: { mdast, body } }) => {
+  // We splice the mdast.
+  let off = 0;
+
+  for (const block of list(findFrontmatter(mdast, body))) {
+    if (block.type === 'frontmatter') {
+      // Replace all the ast nodes making up a frontmatter block
+      // with the respective frontmatter block
+      const dat = {
+        type: 'yaml',
+        payload: block.payload,
+        position: {
+          start: cloneDeep(mdast.children[block.start + off].position.start),
+          end: cloneDeep(mdast.children[block.end + off].position.end),
+          indent: [],
+        },
+      };
+
+      const cnt = block.end - block.start + 1;
+      mdast.children.splice(block.start + off, cnt, dat);
+      off += -cnt + 1; // cnt removed, 1 inserted
+    } else {
+      const { warning, source, start } = block;
+      const fst = mdast.children[start + off];
+
+      // This also needs to account for settext headings
+      // hence the usage of end here, instead of using start
+      const { line } = fst.position.end;
+
+      // Source file pretty printing with line numbers
+      const sourceref = pipe(
+        source.split('\n'),
+        zipLeast2(range(line, Infinity)),
+        map(([l, no]) => `    ${no} | ${l} `),
+        join('\n'),
+      );
+
+      throw new FrontmatterParsingError(`${warning}\n${sourceref}`);
+    }
+  }
+};
+
+parseFrontmatter.does_mutate = true;
+assign(parseFrontmatter, { findFrontmatter, FrontmatterParsingError });
+
+module.exports = parseFrontmatter;

--- a/src/html/parse-markdown.js
+++ b/src/html/parse-markdown.js
@@ -11,56 +11,12 @@
  */
 const unified = require('unified');
 const remark = require('remark-parse');
-const frontmatter = require('remark-frontmatter');
-const map = require('unist-util-map');
-const { safeLoad } = require('js-yaml');
 
-/* eslint-disable no-param-reassign */
-
-/**
- * Injects the `newkids` into the `parent`'s list of children
- * in place of `node`
- * @param {Node} parent the parent node
- * @param {Node} node the child to be replaced
- * @param {Node[]} newkids the new child nodes
- */
-function inject(parent, node, newkids) {
-  const index = parent.children.indexOf(node);
-  const before = parent.children.slice(0, index);
-  const after = parent.children.slice(index + 1);
-
-  parent.children = [...before, ...newkids, ...after];
-}
-
-const thbreak = {
-  type: 'thematicBreak',
-};
-
-function parse({ content: { body = '' } = {} }, { logger }) {
+function parseMarkdown({ content: { body = '' } = {} }, { logger }) {
   logger.debug(`Parsing markdown from request body starting with ${body.split('\n')[0]}`);
-
-  const preprocessor = unified()
-    .use(remark)
-    .use(frontmatter, { type: 'yaml', marker: '-', anywhere: true });
-
-  // see https://github.com/syntax-tree/mdast for documentation
+  const preprocessor = unified().use(remark);
   const mdast = preprocessor.parse(body);
-
-  map(mdast, (node, index, parent) => {
-    if (node.type === 'yaml') {
-      try {
-        const val = safeLoad(node.value);
-        if (typeof val !== 'object') {
-          throw Error('not an object');
-        }
-      } catch (e) {
-        const inner = preprocessor.parse(node.value);
-        inject(parent, node, [thbreak, ...inner.children, thbreak]);
-      }
-    }
-  });
-
   return { content: { mdast } };
 }
 
-module.exports = parse;
+module.exports = parseMarkdown;

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -222,7 +222,7 @@ class Pipeline {
             }
             return args[0];
           });
-        } if (result) {
+        } else if (result) {
           return lastfunc(...args);
         }
         return args[0];

--- a/src/schemas/mdast.schema.json
+++ b/src/schemas/mdast.schema.json
@@ -93,6 +93,10 @@
       "type": "string",
       "description": "The string value of the node, if it is a terminal node."
     },
+    "payload": {
+      "type": "object",
+      "description": "The payload of a frontmatter/yaml block"
+    },
     "depth": {
       "type": "integer",
       "minimum": 1,

--- a/src/utils/conditional-sections.js
+++ b/src/utils/conditional-sections.js
@@ -31,7 +31,7 @@ function selectstrain({ content }, { request, logger }) {
             hidden: !section.meta.strain.includes(strain),
           },
         };
-      } if (section.meta && section.meta.strain) {
+      } else if (section.meta && section.meta.strain) {
         // we treat it as a string
         // return true if the selected strain is in the metadata
         return {

--- a/src/utils/mdast-to-vdom.js
+++ b/src/utils/mdast-to-vdom.js
@@ -106,7 +106,7 @@ class VDOMTransformer {
 
     if (result && typeof result === 'string') {
       return VDOMTransformer.toHTAST(result, cb, node);
-    } if (result && typeof result === 'object' && result.outerHTML) {
+    } else if (result && typeof result === 'object' && result.outerHTML) {
       return VDOMTransformer.toHTAST(result.outerHTML, cb, node);
     }
     return result;

--- a/test/fixtures/confusing.json
+++ b/test/fixtures/confusing.json
@@ -10,7 +10,9 @@
     },
     {
       "type": "yaml",
-      "value": "section: true"
+      "payload": {
+        "section": true
+      }
     },
     {
       "type": "paragraph",

--- a/test/fixtures/confusing.md
+++ b/test/fixtures/confusing.md
@@ -22,4 +22,5 @@ The end.
 
 ---
 
+
 Really.

--- a/test/fixtures/frontmatter.json
+++ b/test/fixtures/frontmatter.json
@@ -2,7 +2,9 @@
   "type": "root",
   "children": [{
       "type": "yaml",
-      "value": "title: foo"
+      "payload": {
+        "title": "foo"
+      }
     },
     {
       "type": "heading",
@@ -126,7 +128,9 @@
     },
     {
       "type": "yaml",
-      "value": "class: section"
+      "payload": {
+        "class": "section"
+      }
     },
     {
       "type": "heading",
@@ -295,7 +299,9 @@
     },
     {
       "type": "yaml",
-      "value": "class: code"
+      "payload": {
+        "class": "code"
+      }
     },
     {
       "type": "heading",

--- a/test/fixtures/frontmatter.md
+++ b/test/fixtures/frontmatter.md
@@ -1,6 +1,7 @@
 ---
 title: foo
 ---
+
 # Hypermedia Pipeline
 
 This project provides helper functions and default implementations for creating Hypermedia Processing Pipelines.

--- a/test/fixtures/sections.json
+++ b/test/fixtures/sections.json
@@ -1,8 +1,11 @@
-[{
+[
+  {
     "type": "root",
     "children": [{
         "type": "yaml",
-        "value": "title: foo"
+        "payload": {
+          "title": "foo"
+        }
       },
       {
         "type": "heading",
@@ -130,7 +133,9 @@
     "type": "root",
     "children": [{
         "type": "yaml",
-        "value": "class: section"
+        "payload": {
+          "class": "section"
+        }
       },
       {
         "type": "heading",
@@ -303,7 +308,9 @@
     "type": "root",
     "children": [{
         "type": "yaml",
-        "value": "class: code"
+        "payload": {
+          "class": "code"
+        }
       },
       {
         "type": "heading",

--- a/test/fixtures/sections.md
+++ b/test/fixtures/sections.md
@@ -1,6 +1,7 @@
 ---
 title: foo
 ---
+
 # Hypermedia Pipeline
 
 This project provides helper functions and default implementations for creating Hypermedia Processing Pipelines.

--- a/test/fixtures/sections/complex.json
+++ b/test/fixtures/sections/complex.json
@@ -21,7 +21,9 @@
     "children": [
       {
         "type": "yaml",
-        "value": "title: foo",
+        "payload": {
+          "title": "foo"
+        },
         "data": {
           "types": []
         }
@@ -218,7 +220,9 @@
     "children": [
       {
         "type": "yaml",
-        "value": "class: section",
+        "payload": {
+          "class": "section"
+        },
         "data": {
           "types": []
         }
@@ -610,7 +614,9 @@
     "children": [
       {
         "type": "yaml",
-        "value": "class: code",
+        "payload": {
+          "class": "code"
+        },
         "data": {
           "types": []
         }

--- a/test/fixtures/sections/complex.md
+++ b/test/fixtures/sections/complex.md
@@ -1,6 +1,7 @@
 ---
 title: foo
 ---
+
 # Hypermedia Pipeline
 
 This project provides helper functions and default implementations for creating Hypermedia Processing Pipelines.

--- a/test/testConditionalSections.js
+++ b/test/testConditionalSections.js
@@ -429,7 +429,13 @@ Or that one at the same time, because they are both part of an A/B test.
       return selected;
     }
 
-    assert.notDeepEqual(await runpipe('foo'), await runpipe('bar'));
+    // The terms/strains below *happen* to work. They *happen* to produce
+    // different hash values for the current section format and content above.
+    // If this test fails – especially if you changed anything about the section
+    // format, section metadata, the mdast format or the input above, you probably
+    // want to change one of these values until you find one that *happens* to work
+    // again...
+    assert.notDeepEqual(await runpipe('foo'), await runpipe('bang'));
     assert.deepEqual(await runpipe('baz'), await runpipe('baz'));
   });
 });

--- a/test/testFrontmatter.js
+++ b/test/testFrontmatter.js
@@ -1,0 +1,420 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+const winston = require('winston');
+const assert = require('assert');
+const { cloneDeep } = require('lodash');
+const yaml = require('js-yaml');
+const { multiline } = require('@adobe/helix-shared').string;
+const {
+  flattenTree, concat, each,
+} = require('@adobe/helix-shared').sequence;
+const parseMd = require('../src/html/parse-markdown');
+const parseFront = require('../src/html/parse-frontmatter');
+
+const { FrontmatterParsingError } = parseFront;
+
+const logger = winston.createLogger({
+  silent: true,
+  format: winston.format.simple(),
+  transports: [
+    new winston.transports.Console(),
+  ],
+});
+
+const procMd = (md) => {
+  const body = multiline(md);
+  const { mdast: orig } = parseMd({ content: { body } }, { logger }).content;
+  const proc = cloneDeep(orig);
+  parseFront({ content: { mdast: proc, body } });
+  return { orig, proc };
+};
+
+const ck = (wat, md, ast) => {
+  it(wat, () => {
+    const { proc } = procMd(md);
+    // Discard position info
+    const nodes = flattenTree(proc,
+      (node, recurse) => concat([node], recurse(node.children || [])));
+    each(nodes, (node) => {
+      /* eslint-disable-next-line no-param-reassign */
+      delete node.position;
+    });
+    assert.deepStrictEqual(proc.children, yaml.safeLoad(ast));
+  });
+};
+
+const ckNop = (wat, md) => {
+  it(`${wat} should be ignored`, () => {
+    const { proc, orig } = procMd(md);
+    assert.deepStrictEqual(proc, orig);
+  });
+};
+
+const ckErr = (wat, body) => {
+  it(`${wat} should raise exception`, () => {
+    assert.throws(() => procMd(body), FrontmatterParsingError);
+  });
+};
+
+describe('parseFrontmatter', () => {
+  // NOPs
+  ckNop('Empty document', '');
+  ckNop('Just some text', 'Foo');
+  ckNop('Hash based second level header', '## Foo');
+  ckNop('Underline second level header', `
+    Hello World
+    ---
+  `);
+  ckNop('Single <hr>', `
+    ---
+  `);
+  ckNop('h2 with underline followed by <hr>', `
+    Hello
+    ---
+
+    ---
+  `);
+
+  ckNop('diversity of h2 with underline and <hr>', `
+    Hello
+    ---
+
+    Bar
+    ---
+
+    ---
+
+    Bang
+  `);
+
+  ckNop('resolving ambiguity by using h2 underlined with 4 dashes', `
+    Foo
+    ----
+    Hello
+    ----
+  `);
+
+  ckNop('resolving ambiguity by using hr with spaces between dashes', `
+    Foo
+    - - -
+    Hello
+  `);
+
+  ckNop('resolving ambiguity by using hr with spaces between dashes', `
+    Foo
+
+    - - -
+    Hello: 13
+    - - -
+
+    Bar
+  `);
+
+  ckNop('resolving ambiguity by using hr with asterisk', `
+    Foo
+    ***
+    Hello
+  `);
+
+  ckNop('resolving ambiguity by using hr with asterisk #2', `
+    ***
+    Foo: 42
+    ***
+  `);
+
+  // actual warnings
+  ckErr('reject yaml with list', `
+    ---
+    - Foo
+    ---
+  `);
+  ckErr('reject yaml with json style list', `
+    ---
+    [1,2,3,4]
+    ---
+  `);
+  ckErr('reject yaml with number', `
+    ---
+    42
+    ---
+  `);
+  ckErr('reject yaml with string', `
+    ---
+    Hello
+    ---
+  `);
+  ckErr('Reject yaml with null', `
+    ---
+    null
+    ---
+  `);
+  ckErr('frontmatter with corrupted yaml', `
+      Foo
+      ---
+      Bar: 42
+      ---
+    `);
+  ckErr('frontmatter with insufficient space before it', `
+      Foo
+      ---
+      Bar: 42
+      ---
+    `);
+  ckErr('frontmatter with insufficient space after it', `
+      ---
+      Bar
+      ---
+      XXX
+    `);
+  ckErr('frontmatter with insufficient space on both ends', `
+      ab: 33
+      ---
+      Bar: 22
+      ---
+      XXX: 44
+    `);
+  ckErr('frontmatter with empty line between paragraphs', `
+      echo
+
+      ---
+      hello: 42
+
+      world: 13
+      ---
+
+      delta
+    `);
+  ckErr('frontmatter with empty line', `
+      ---
+      hello: 42
+
+      world: 13
+      ---
+    `);
+  ckErr('frontmatter with empty line filled with space', `
+      ---
+      hello: 42
+
+      world: 13
+      ---
+    `);
+
+  // Good values
+
+  ck('Entire doc is frontmatter', `
+    ---
+    foo: 42
+    ---
+  `, `
+    - type: yaml
+      payload:
+        foo: 42
+  `);
+
+  ck('Entire doc is frontmatter w trailing space', `
+    ---
+    foo: 42
+    ---
+  `, `
+    - type: yaml
+      payload:
+        foo: 42
+  `);
+
+  ck('Frontmatter; underline h2; frontmatter', `
+    ---
+    foo: 42
+    ---
+
+    Hello
+    ---
+
+    ---
+    my: 42
+    ---
+  `, `
+    - type: yaml
+      payload:
+        foo: 42
+    - type: heading
+      depth: 2
+      children:
+        - type: text
+          value: Hello
+    - type: yaml
+      payload:
+        my: 42
+  `);
+
+  ck('Frontmatter; underline h2; frontmatter; w trailing space', `
+    ---
+    foo: 42
+    ---
+
+    Hello
+    ---
+
+    ---
+    my: 42
+    ---
+  `, `
+    - type: yaml
+      payload:
+        foo: 42
+    - type: heading
+      depth: 2
+      children:
+        - type: text
+          value: Hello
+    - type: yaml
+      payload:
+        my: 42
+  `);
+
+  ck('frontmatter; frontmatter', `
+    ---
+    {x: 23}
+    ---
+
+    ---
+    my: 42
+    ---
+  `, `
+    - type: yaml
+      payload:
+        x: 23
+    - type: yaml
+      payload:
+        my: 42
+  `);
+  ck('frontmatter, <hr>, frontmatter', `
+    ---
+    {x: 23}
+    ---
+
+    ---
+
+    ---
+    my: 42
+    ---
+  `, `
+    - type: yaml
+      payload:
+        x: 23
+    - type: thematicBreak
+    - type: yaml
+      payload:
+        my: 42
+  `);
+  ck('frontmatter, text, frontmatter', `
+    ---
+    {x: 23}
+    ---
+
+    Hurtz
+
+    ---
+    my: 42
+    ---
+  `, `
+    - type: yaml
+      payload:
+        x: 23
+    - type: paragraph
+      children:
+        - type: text
+          value: Hurtz
+    - type: yaml
+      payload:
+        my: 42
+  `);
+  ck('frontmatter, <hr>, frontmatter, <hr>', `
+    ---
+    {x: 23}
+    ---
+
+    ---
+
+    ---
+    my: 42
+    ---
+
+    ---
+  `, `
+    - type: yaml
+      payload:
+        x: 23
+    - type: thematicBreak
+    - type: yaml
+      payload:
+        my: 42
+    - type: thematicBreak
+  `);
+  ck('frontmatter, text, frontmatter, text, frontmatter, text, frontmatter, text', `
+    ---
+    {x: 23}
+    ---
+
+    Hurtz
+
+    ---
+    my: 42
+    ---
+
+    Bong
+
+    ---
+    nom: foo
+    ---
+
+    Huck
+
+    ---
+    nom: foo
+    ---
+
+    Huck
+
+
+
+  `, `
+    - type: yaml
+      payload:
+        x: 23
+    - type: paragraph
+      children:
+        - type: text
+          value: Hurtz
+    - type: yaml
+      payload:
+        my: 42
+    - type: paragraph
+      children:
+        - type: text
+          value: Bong
+    - type: yaml
+      payload:
+        nom: foo
+    - type: paragraph
+      children:
+        - type: text
+          value: Huck
+    - type: yaml
+      payload:
+        nom: foo
+    - type: paragraph
+      children:
+        - type: text
+          value: Huck
+  `);
+});

--- a/test/testGetMetadata.js
+++ b/test/testGetMetadata.js
@@ -14,6 +14,7 @@ const assert = require('assert');
 const { Logger } = require('@adobe/helix-shared');
 const parse = require('../src/html/parse-markdown');
 const split = require('../src/html/split-sections');
+const parseFront = require('../src/html/parse-frontmatter');
 const { assertMatchDir } = require('./markdown-utils');
 const getmetadata = require('../src/html/get-metadata');
 
@@ -23,8 +24,10 @@ const logger = Logger.getTestLogger({
 });
 
 function callback(body) {
-  const parsed = split(parse({ content: { body } }, { logger }), { logger });
-  return getmetadata(parsed, { logger }).content.sections;
+  const parsed = parse({ content: { body } }, { logger });
+  parseFront({ content: { mdast: parsed.content.mdast, body } });
+  const splitted = split(parsed, { logger });
+  return getmetadata(splitted, { logger }).content.sections;
 }
 
 const SECTIONS_BLOCS = [

--- a/test/testHelper.js
+++ b/test/testHelper.js
@@ -26,6 +26,6 @@ describe('Test bail', () => {
   });
 
   it('Bail logs something', (done) => {
-    helper.bail({ error: () => { done(); } }, 'This is bad');
+    helper.bail({ error: () => done() }, 'This is bad');
   });
 });

--- a/test/testParseMarkdown.js
+++ b/test/testParseMarkdown.js
@@ -12,6 +12,7 @@
 /* eslint-env mocha */
 const { Logger } = require('@adobe/helix-shared');
 const parse = require('../src/html/parse-markdown');
+const parseFront = require('../src/html/parse-frontmatter');
 const { assertMatch } = require('./markdown-utils');
 
 const logger = Logger.getTestLogger({
@@ -20,7 +21,9 @@ const logger = Logger.getTestLogger({
 });
 
 function callback(body) {
-  return parse({ content: { body } }, { logger }).content.mdast;
+  const { mdast } = parse({ content: { body } }, { logger }).content;
+  parseFront({ content: { mdast, body } });
+  return mdast;
 }
 
 describe('Test Markdown Parsing', () => {

--- a/test/testPipeline.js
+++ b/test/testPipeline.js
@@ -144,7 +144,7 @@ describe('Testing Pipeline', () => {
   it('Logs correct names', (done) => {
     const order = [];
 
-    const pre0 = () => { order.push('pre0'); };
+    const pre0 = () => order.push('pre0');
     const post0 = function post0() {
       order.push('post0');
     };
@@ -393,7 +393,12 @@ describe('Testing Pipeline', () => {
     new Pipeline({ logger })
       .before(() => ({ foo: 'bar' }))
       .after(() => ({ bar: 'baz' }))
-      .every((c, a, i) => { if (i === 1) { done(); } return true; })
+      .every((c, a, i) => {
+        if (i === 1) {
+          done();
+        }
+        return true;
+      })
       .run();
   });
 
@@ -401,9 +406,19 @@ describe('Testing Pipeline', () => {
     new Pipeline({ logger })
       .before(() => ({ foo: 'bar' }))
       .after(() => ({ bar: 'baz' }))
-      .every((c, a, i) => { if (i === 1) { done(new Error('this is a trap')); } return true; })
+      .every((c, a, i) => {
+        if (i === 1) {
+          done(new Error('this is a trap'));
+        }
+        return true;
+      })
       .when(() => false)
-      .every((c, a, i) => { if (i === 1) { done(); } return true; })
+      .every((c, a, i) => {
+        if (i === 1) {
+          done();
+        }
+        return true;
+      })
       .when(() => true)
       .run();
   });
@@ -428,7 +443,10 @@ describe('Testing Pipeline', () => {
   it('skip functions if context.error', (done) => {
     const order = [];
     new Pipeline({ logger })
-      .before(() => { order.push('pre0'); return { error: 'stop' }; })
+      .before(() => {
+        order.push('pre0');
+        return { error: 'stop' };
+      })
       .before(() => { order.push('pre1'); })
       .once(() => { order.push('once'); })
       .after(() => { order.push('post0'); })
@@ -445,7 +463,10 @@ describe('Testing Pipeline', () => {
   it('skip functions if exception', (done) => {
     const order = [];
     new Pipeline({ logger })
-      .before(() => { order.push('pre0'); throw new Error('stop'); })
+      .before(() => {
+        order.push('pre0');
+        throw new Error('stop');
+      })
       .before(() => { order.push('pre1'); })
       .once(() => { order.push('once'); })
       .after(() => { order.push('post0'); })
@@ -462,9 +483,15 @@ describe('Testing Pipeline', () => {
   it('error handler can clear error', (done) => {
     const order = [];
     new Pipeline({ logger })
-      .before(() => { order.push('pre0'); throw new Error('stop'); })
+      .before(() => {
+        order.push('pre0');
+        throw new Error('stop');
+      })
       .before(() => { order.push('pre1'); })
-      .error(() => { order.push('error0'); return { error: null }; })
+      .error(() => {
+        order.push('error0');
+        return { error: null };
+      })
       .once(() => { order.push('once'); })
       .after(() => { order.push('post0'); })
       .after(() => { order.push('post1'); })

--- a/test/testSplitSections.js
+++ b/test/testSplitSections.js
@@ -13,6 +13,7 @@
 const { Logger } = require('@adobe/helix-shared');
 const parse = require('../src/html/parse-markdown');
 const split = require('../src/html/split-sections');
+const parseFront = require('../src/html/parse-frontmatter');
 const { assertMatch } = require('./markdown-utils');
 
 const logger = Logger.getTestLogger({
@@ -22,6 +23,7 @@ const logger = Logger.getTestLogger({
 
 function callback(body) {
   const parsed = parse({ content: { body } }, { logger });
+  parseFront({ content: { mdast: parsed.content.mdast, body } });
   return split(parsed, { logger }).content.sections;
 }
 


### PR DESCRIPTION
feat(html pipe): Manual & improved frontmatter parsing

* Reduce number of dependencies
* Yaml is accessible in the main mdast, not only in section metadata
* Parsing & decoding frontmatter in one step
* Explicit constraints on what is parsed as frontmatter and what is not
  Before this we  would interpret pretty much anything as a frontmatter block and juust discard blocks that happened to not be valid yaml. This PR decouples the frontmatter detection from the actual content parsing.
* Helpful error messages for ambigous frontmatter blocks & frontmatter
  blocks that could not be parsed
* Reduces complexity in how yaml constraints are applied: No need to
  revert frontmatter blocks to normal markdown when constraints
  disqualify them; these blocks are just never converted to yaml ast
  nodes
* Handles a few edge cases better

```
Paragraph.

---

Item One: Clearly two description style paragraphs sandwhiched between <hr>

Item Two: Which are instead interpreted as yaml!

---
```

```
Paragraph.

---

Heading with colon: Right after <hr>
---
```

```
Paragraph.

---

+ Description style: list with plus
+ That is: sandwiched between <hr>

---
```