### PR TITLE
fix(markdown): Fix handling of references in Markdown validation

### DIFF
--- a/docs/mdast.schema.json
+++ b/docs/mdast.schema.json
@@ -178,6 +178,19 @@
             ],
             "description": "An alt field should be present. It represents equivalent content for environments that cannot represent the node as intended."
         },
+        "referenceType": {
+            "enum": [
+                "shortcut",
+                "collapsed",
+                "full"
+            ],
+            "description": "Represents the explicitness of a reference.",
+            "meta:enum": {
+                "shortcut": "the reference is implicit, its identifier inferred from its content",
+                "collapsed": "the reference is explicit, its identifier inferred from its content",
+                "full": "the reference is explicit, its identifier explicitly set"
+            }
+        },
         "data": {
             "type": "object",
             "description": "data is guaranteed to never be specified by unist or specifications implementing unist. Free data space.",

--- a/docs/mdast.schema.md
+++ b/docs/mdast.schema.md
@@ -32,6 +32,7 @@ A node in the Markdown AST
 | [meta](#meta) | complex | Optional | MDAST (this schema) |
 | [ordered](#ordered) | `boolean` | Optional | MDAST (this schema) |
 | [position](#position) | Position | Optional | MDAST (this schema) |
+| [referenceType](#referencetype) | `enum` | Optional | MDAST (this schema) |
 | [spread](#spread) | complex | Optional | MDAST (this schema) |
 | [start](#start) | complex | Optional | MDAST (this schema) |
 | [title](#title) | complex | Optional | MDAST (this schema) |
@@ -313,6 +314,27 @@ Is the list ordered
 
 * [Position](position.schema.md) – `https://ns.adobe.com/helix/pipeline/position`
 
+
+
+
+
+## referenceType
+
+Represents the explicitness of a reference.
+
+`referenceType`
+* is optional
+* type: `enum`
+* defined in this schema
+
+The value of this property **must** be equal to one of the [known values below](#referencetype-known-values).
+
+### referenceType Known Values
+| Value | Description |
+|-------|-------------|
+| `shortcut` | the reference is implicit, its identifier inferred from its content |
+| `collapsed` | the reference is explicit, its identifier inferred from its content |
+| `full` | the reference is explicit, its identifier explicitly set |
 
 
 

--- a/src/schemas/mdast.schema.json
+++ b/src/schemas/mdast.schema.json
@@ -152,6 +152,15 @@
       "type": ["string", "null"],
       "description": "An alt field should be present. It represents equivalent content for environments that cannot represent the node as intended."
     },
+    "referenceType": {
+      "enum": ["shortcut", "collapsed", "full"],
+      "description": "Represents the explicitness of a reference.",
+      "meta:enum": {
+        "shortcut": "the reference is implicit, its identifier inferred from its content",
+        "collapsed": "the reference is explicit, its identifier inferred from its content",
+        "full": "the reference is explicit, its identifier explicitly set"
+      }
+    },
     "data": {
       "type": "object",
       "description": "data is guaranteed to never be specified by unist or specifications implementing unist. Free data space.",

--- a/test/fixtures/index-modified.md
+++ b/test/fixtures/index-modified.md
@@ -31,3 +31,6 @@ It works! {{project.name}} is up and running.
 5. Publish your project to GitHub: `git add git remote add origin https://github.com/user/repo.git && git push`
 6. Deploy the project: `hlx deploy`
 7. Make it visible to the world: `hlx publish`
+
+> [!NOTE]
+> This is intended to break.

--- a/test/testHTMLFromMarkdown.js
+++ b/test/testHTMLFromMarkdown.js
@@ -145,4 +145,12 @@ describe('Testing Markdown conversion', () => {
       '<pre><code>Hello World\n</code></pre>',
     );
   });
+
+  it('Link references', async () => {
+    await assertMd(
+      `Hello [World]
+[World]: http://example.com`,
+      '<p>Hello <a href="http://example.com">World</a></p>',
+    );
+  });
 });


### PR DESCRIPTION
Adds the neccessary schema for referenceType and a corresponding integration test

fixes #159 needed by https://github.com/adobe/helix-cli/pull/653