### PR TITLE
chore: improve error logs

### DIFF
--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -355,7 +355,7 @@ class Pipeline {
             return result;
           })).catch((e) => {
           // tapping failed
-          this._action.logger.warn(`tapping failed: ${e}`, e);
+          this._action.logger.error(`tapping failed: ${e.stack}`);
           return {
             error: `${currContext.error || ''}\n${e.stack || ''}`,
           };

--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -15,13 +15,11 @@ function validate(context, action, index) {
   const validator = ajv(action.logger);
   const cvalid = validator.validate('https://ns.adobe.com/helix/pipeline/context', context);
   if (!cvalid) {
-    action.logger.warn(`Invalid Context at step ${index}, ${validator.errorsText()}`);
-    throw new Error(`Invalid Context at step ${index}\n${validator.errorsText()}`);
+    throw new Error(`Invalid Context at step ${index}: \n${validator.enhancedErrorsText()}`);
   }
   const avalid = validator.validate('https://ns.adobe.com/helix/pipeline/action', action);
   if (!avalid) {
-    action.logger.warn(`Invalid Action at step ${index}, ${validator.errorsText()}`);
-    throw new Error(`Invalid Action at step ${index}\n${validator.errorsText()}`);
+    throw new Error(`Invalid Action at step ${index}: \n${validator.enhancedErrorsText()}`);
   }
 }
 

--- a/src/utils/validator.js
+++ b/src/utils/validator.js
@@ -13,6 +13,7 @@
 const Ajv = require('ajv');
 const path = require('path');
 const hash = require('object-hash');
+const util = require('util');
 
 const _ajv = {};
 
@@ -57,8 +58,10 @@ function ajv(logger, options = {}) {
         if (err) {
           if (err.data && err.data.type) {
             text += `${err.data.type}${err.schemaPath} ${err.message} - path: ${err.dataPath}${separator}`;
+          } else if (typeof err.data !== 'object') {
+            text += `${err.schemaPath} ${err.message} - params: ${JSON.stringify(util.inspect(err.params))} - value: ${err.data} - path: ${err.dataPath}${separator}`;
           } else {
-            text += `${err.schemaPath} ${err.message} - value: ${err.data} - path: ${err.dataPath}${separator}`;
+            text += `${err.schemaPath} ${err.message} - params: ${JSON.stringify(util.inspect(err.params))} - path: ${err.dataPath}${separator}`;
           }
         }
       });

--- a/src/utils/validator.js
+++ b/src/utils/validator.js
@@ -45,6 +45,26 @@ function ajv(logger, options = {}) {
       validator.addSchema(schemaData);
       logger.debug(`- ${schemaData.$id}  (${path.basename(schemaFile)})`);
     });
+
+    validator.enhancedErrorsText = function enhancedErrorsText(errs, opts = {}) {
+      const errors = errs || this.errors;
+      if (!errors) return 'No errors';
+
+      const separator = opts.separator === undefined ? '\n' : opts.separator;
+
+      let text = '';
+      errors.forEach((err) => {
+        if (err) {
+          if (err.data && err.data.type) {
+            text += `${err.data.type}${err.schemaPath} ${err.message} - path: ${err.dataPath}${separator}`;
+          } else {
+            text += `${err.schemaPath} ${err.message} - value: ${err.data} - path: ${err.dataPath}${separator}`;
+          }
+        }
+      });
+      return text.slice(0, -separator.length);
+    }.bind(validator);
+
     logger.debug('ajv initialized');
     _ajv[hash(options)] = validator;
   }

--- a/test/testHTML.js
+++ b/test/testHTML.js
@@ -321,6 +321,44 @@ ${content.document.body.innerHTML}`,
     assert.equal(result.error.split('\n')[2], '#/additionalProperties should NOT have additional properties - params: "{ additionalProperty: \'foo\' }" - path: .content');
   });
 
+  it('html.pipe complains with a specific message for mdast nodes when context is invalid', async () => {
+    const result = await pipe(
+      ({ content }) => ({ response: { status: 201, body: content.document.body.innerHTML } }),
+      {
+        content: {
+          sections: [{ type: 'notroot' }],
+        },
+      },
+      {
+        request: { params },
+        secrets,
+        logger,
+      },
+    );
+    assert.ok(result.error);
+    assert.equal(result.error.split('\n')[1], 'Error: Invalid Context at step 0: ');
+    assert.equal(result.error.split('\n')[2], '#/properties/type/const should be equal to constant - params: "{ allowedValue: \'root\' }" - value: notroot - path: .content.sections[0].type');
+  });
+
+  it('html.pipe complains with a specific message for mdast nodes wih extra properties when context is invalid', async () => {
+    const result = await pipe(
+      ({ content }) => ({ response: { status: 201, body: content.document.body.innerHTML } }),
+      {
+        content: {
+          sections: [{ type: 'root', custom: 'notallowed' }],
+        },
+      },
+      {
+        request: { params },
+        secrets,
+        logger,
+      },
+    );
+    assert.ok(result.error);
+    assert.equal(result.error.split('\n')[1], 'Error: Invalid Context at step 0: ');
+    assert.equal(result.error.split('\n')[2], 'root#/additionalProperties should NOT have additional properties - path: .content.sections[0]');
+  });
+
   it('html.pipe complains when action is invalid', async () => {
     const result = await pipe(
       ({ content }) => ({ response: { status: 201, body: content.document.body.innerHTML } }),

--- a/test/testHTML.js
+++ b/test/testHTML.js
@@ -317,8 +317,8 @@ ${content.document.body.innerHTML}`,
       },
     );
     assert.ok(result.error);
-    assert.equal(result.error.split('\n')[1], 'Error: Invalid Context at step 0');
-    assert.equal(result.error.split('\n')[2], 'data.content should NOT have additional properties');
+    assert.equal(result.error.split('\n')[1], 'Error: Invalid Context at step 0: ');
+    assert.equal(result.error.split('\n')[2], '#/additionalProperties should NOT have additional properties - params: "{ additionalProperty: \'foo\' }" - path: .content');
   });
 
   it('html.pipe complains when action is invalid', async () => {
@@ -337,8 +337,8 @@ ${content.document.body.innerHTML}`,
       },
     );
     assert.ok(result.error);
-    assert.equal(result.error.split('\n')[1], 'Error: Invalid Action at step 0');
-    assert.equal(result.error.split('\n')[2], 'data should NOT have additional properties');
+    assert.equal(result.error.split('\n')[1], 'Error: Invalid Action at step 0: ');
+    assert.equal(result.error.split('\n')[2], '#/additionalProperties should NOT have additional properties - params: "{ additionalProperty: \'break\' }" - path: ');
   });
 
   it('html.pipe makes HTTP requests', async () => {


### PR DESCRIPTION
PR (no issue) to improve error logs.

Instead of

```
[hlx] warn: tapping failed: ReferenceError: addListMetadata is not definedaddListMetadata is not defined
```

you get now

```
[hlx] error: tapping failed: ReferenceError: addListMetadata is not defined
    at Object.filter (/Users/alex/work/dev/helix/hackathon/helix-sections-playground/.hlx/build/superfilter.js:40:3)
    at c.sections.forEach (/Users/alex/work/dev/helix/hackathon/helix-sections-playground/.hlx/build/object_json.js:22:17)
    at Array.forEach (<anonymous>)
    at main (/Users/alex/work/dev/helix/hackathon/helix-sections-playground/.hlx/build/object_json.js:21:14)
    at invoker (/Users/alex/work/dev/helix/hackathon/helix-sections-playground/.hlx/build/object_json.js:53:32)

```

And

Instead of

```
[hlx] warn: Invalid Context at step 6, data.content.sections[7].children[1].children[0] should NOT have additional properties, data.content.sections[7].children[1].children[1] should NOT have additional properties, data.content.sections[7].children[1].children[2] should NOT have additional properties, data.content.sections[7].children[1].children[3] should NOT have additional properties, data.content.sections[7].children[1].depth should be >= 1, data.content.sections[8].children[0].children[0] should NOT have additional properties, data.content.sections[8].children[0].children[1] should NOT have additional properties, data.content.sections[8].children[0].children[2] should NOT have additional properties, data.content.sections[8].children[0].children[3] should NOT have additional properties, data.content.sections[8].children[0].depth should be >= 1, data.content.sections[9].children[0].children[0] should NOT have additional properties, data.content.sections[9].children[0].children[1] should NOT have additional properties, data.content.sections[9].children[0].children[2] should NOT have additional properties, data.content.sections[9].children[0].depth should be >= 1
[hlx] warn: tapping failed: Error: Invalid Context at step 6
data.content.sections[7].children[1].children[0] should NOT have additional properties, data.content.sections[7].children[1].children[1] should NOT have additional properties, data.content.sections[7].children[1].children[2] should NOT have additional properties, data.content.sections[7].children[1].children[3] should NOT have additional properties, data.content.sections[7].children[1].depth should be >= 1, data.content.sections[8].children[0].children[0] should NOT have additional properties, data.content.sections[8].children[0].children[1] should NOT have additional properties, data.content.sections[8].children[0].children[2] should NOT have additional properties, data.content.sections[8].children[0].children[3] should NOT have additional properties, data.content.sections[8].children[0].depth should be >= 1, data.content.sections[9].children[0].children[0] should NOT have additional properties, data.content.sections[9].children[0].children[1] should NOT have additional properties, data.content.sections[9].children[0].children[2] should NOT have additional properties, data.content.sections[9].children[0].depth should be >= 1Invalid Context at step 6
data.content.sections[7].children[1].children[0] should NOT have additional properties, data.content.sections[7].children[1].children[1] should NOT have additional properties, data.content.sections[7].children[1].children[2] should NOT have additional properties, data.content.sections[7].children[1].children[3] should NOT have additional properties, data.content.sections[7].children[1].depth should be >= 1, data.content.sections[8].children[0].children[0] should NOT have additional properties, data.content.sections[8].children[0].children[1] should NOT have additional properties, data.content.sections[8].children[0].children[2] should NOT have additional properties, data.content.sections[8].children[0].children[3] should NOT have additional properties, data.content.sections[8].children[0].depth should be >= 1, data.content.sections[9].children[0].children[0] should NOT have additional properties, data.content.sections[9].children[0].children[1] should NOT have additional properties, data.content.sections[9].children[0].children[2] should NOT have additional properties, data.content.sections[9].children[0].depth should be >= 1
```

you get now

```
[hlx] error: tapping failed: Error: Invalid Context at step 6: 
listItem#/additionalProperties should NOT have additional properties - path: .content.sections[7].children[1].children[0]
listItem#/additionalProperties should NOT have additional properties - path: .content.sections[7].children[1].children[1]
listItem#/additionalProperties should NOT have additional properties - path: .content.sections[7].children[1].children[2]
listItem#/additionalProperties should NOT have additional properties - path: .content.sections[7].children[1].children[3]
#/properties/depth/minimum should be >= 1 - params: "{ comparison: '>=', limit: 1, exclusive: false }" - value: 0 - path: .content.sections[7].children[1].depth
listItem#/additionalProperties should NOT have additional properties - path: .content.sections[8].children[0].children[0]
listItem#/additionalProperties should NOT have additional properties - path: .content.sections[8].children[0].children[1]
listItem#/additionalProperties should NOT have additional properties - path: .content.sections[8].children[0].children[2]
listItem#/additionalProperties should NOT have additional properties - path: .content.sections[8].children[0].children[3]
#/properties/depth/minimum should be >= 1 - params: "{ comparison: '>=', limit: 1, exclusive: false }" - value: 0 - path: .content.sections[8].children[0].depth
listItem#/additionalProperties should NOT have additional properties - path: .content.sections[9].children[0].children[0]
listItem#/additionalProperties should NOT have additional properties - path: .content.sections[9].children[0].children[1]
listItem#/additionalProperties should NOT have additional properties - path: .content.sections[9].children[0].children[2]
#/properties/depth/minimum should be >= 1 - params: "{ comparison: '>=', limit: 1, exclusive: false }" - value: 0 - path: .content.sections[9].children[0].depth
    at validate (/Users/alex/work/dev/helix/project-helix/modules/helix-pipeline/src/utils/validate.js:18:11)
    at wrappedfunc (/Users/alex/work/dev/helix/project-helix/modules/helix-pipeline/src/pipeline.js:226:18)
    at tapresults._taps.map (/Users/alex/work/dev/helix/project-helix/modules/helix-pipeline/src/pipeline.js:344:18)
    at Array.map (<anonymous>)
    at merge (/Users/alex/work/dev/helix/project-helix/modules/helix-pipeline/src/pipeline.js:342:37)
    at filter.reduce (/Users/alex/work/dev/helix/project-helix/modules/helix-pipeline/src/pipeline.js:370:41)
```

For the ajv logs, this is really specific to our needs, but I think it is a must-have to provide meaningful log messages. It might not cover all the error case but at least it should have some info to understand what is wrong in the content vs schema.