### PR TITLE
#26 - Add support for anchors on headings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@adobe/helix-pipeline",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@adobe/helix-shared": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared/-/helix-shared-0.8.4.tgz",
-      "integrity": "sha512-/jOtKILc21XhuPXy8ahQBHFc7WAfrpAVymOwB4h58a5to/nLwoczJkzxidrQR21ENI5cOrKyBoXOUoOjnREOEQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared/-/helix-shared-0.10.0.tgz",
+      "integrity": "sha512-yEJpCsGcCPumKNXTHqFoP104BS2t6C4Y/+ajM9GWmlfc7QGsJ4FrdCZKzxiIZRalSJjbdu/3h1O9nIN0najzDA==",
       "requires": {
         "ajv": "6.10.0",
         "fs-extra": "^7.0.0",
@@ -181,6 +181,27 @@
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
           "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
           "dev": true
+        }
+      }
+    },
+    "@babel/runtime-corejs2": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.4.3.tgz",
+      "integrity": "sha512-anTLTF7IK8Hd5f73zpPzt875I27UaaTWARJlfMGgnmQhvEe1uNHQRKBUbXL0Gc0VEYiVzsHsTPso5XdK8NGvFg==",
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
         }
       }
     },
@@ -4197,6 +4218,12 @@
             "isarray": "0.0.1",
             "string_decoder": "~0.10.x"
           }
+        },
+        "xregexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
+          "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=",
+          "dev": true
         }
       }
     },
@@ -14903,10 +14930,12 @@
       "dev": true
     },
     "xregexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
-      "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=",
-      "dev": true
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.2.4.tgz",
+      "integrity": "sha512-sO0bYdYeJAJBcJA8g7MJJX7UrOZIfJPd8U2SC7B2Dd/J24U0aQNoGp33shCaBSWeb0rD5rh6VBUIXOkGal1TZA==",
+      "requires": {
+        "@babel/runtime-corejs2": "^7.2.0"
+      }
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "uri-js": "^4.2.2",
     "winston": "^3.0.0",
     "xml2js": "^0.4.19",
-    "xmlbuilder": "^11.0.0"
+    "xmlbuilder": "^11.0.0",
+    "xregexp": "^4.2.4"
   },
   "snyk": true,
   "lint-staged": {

--- a/src/utils/generate-html-id.js
+++ b/src/utils/generate-html-id.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+const XRegExp = require('xregexp');
+
+module.exports = {
+  /**
+   * Generates a valid HTML identifier from the string
+   * @param {string} text The text to use to generate the identifier
+   * @returns {string} the string for the identifier
+   */
+  generateId: (text) => {
+    const unicodeWord = XRegExp('[^\\pL\\pN _-]+', 'g'); // Accept unicode letters, numbers, space, underscore and '-'
+    return text.toLowerCase()
+      .replace(/\s/g, '-') // replace white-spaces by '-'
+      .replace(unicodeWord, ''); // remove all non-letters
+  },
+
+};

--- a/src/utils/heading-handler.js
+++ b/src/utils/heading-handler.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const fallback = require('mdast-util-to-hast/lib/handlers/heading');
+
+/**
+ * Generates a valid HTML identifier from the string
+ * @param {string} text The text to use to generate the identifier
+ * @returns {string} the string for the identifier
+ */
+function generateId(text) {
+  return text.toLowerCase()
+    .replace(/[^a-z0-9]/g, '-') // replace non-alphanumerical characters by '-'
+    .replace(/-+/g, '-') // replace consecutive '-' by a single instance
+    .replace(/(^-|-$)/g, ''); // trim leading and tailing '-';
+}
+
+/**
+ * Gets the list of parent heading nodes for the specified heading.
+ * @param {UnistParent~Parent} parent The parent node for the MDAST
+ * @param {UnistParent~Heading} heading The heading node to get the parents of
+ * @returns {UnistParent~Heading[]} The list of parent headings
+ */
+function getParentHeadings(parent, heading) {
+  const currentHeadingIndex = parent.children.indexOf(heading);
+  if (currentHeadingIndex === -1) {
+    return [];
+  }
+  let { depth } = heading;
+  let parentHeadings = parent.children.slice(0, currentHeadingIndex).filter(n => n.type === 'heading');
+  parentHeadings = parentHeadings.reverse().reduce((headings, h) => {
+    if (h.depth < depth) {
+      headings.push(h);
+      depth -= 1;
+    }
+    return headings;
+  }, []);
+  return parentHeadings.reverse();
+}
+
+function headingHandler() {
+  return function handler(h, node, parent) {
+    // Prepare the heading id (prefixed with the ids of its parent headings)
+    const headings = getParentHeadings(parent, node);
+    headings.push(node);
+    const headingsIdentifier = headings.map(heading => generateId(heading.children[0].value)).join('--');
+
+    // Inject the id after transformation
+    const n = Object.assign({}, node);
+    const el = fallback(h, n);
+    el.properties.id = headingsIdentifier;
+    return el;
+  };
+}
+
+module.exports = headingHandler;

--- a/src/utils/heading-handler.js
+++ b/src/utils/heading-handler.js
@@ -32,9 +32,6 @@ function generateId(text) {
  */
 function getParentHeadings(parent, heading) {
   const currentHeadingIndex = parent.children.indexOf(heading);
-  if (currentHeadingIndex === -1) {
-    return [];
-  }
   let { depth } = heading;
   let parentHeadings = parent.children.slice(0, currentHeadingIndex).filter(n => n.type === 'heading');
   parentHeadings = parentHeadings.reverse().reduce((headings, h) => {

--- a/src/utils/heading-handler.js
+++ b/src/utils/heading-handler.js
@@ -59,7 +59,7 @@ function headingHandler() {
     let headingIdentifier = HtmlId.generateId(getTextContent(node));
 
     // Verify existing headings for a collision and append a suffix if needed
-    headingIdentifier = suffixHeadingIdentifier(headingIdentifier, headingIdentifiersCache);
+    headingIdentifier = suffixHeadingIdentifier(headingIdentifier);
 
     // Inject the id after transformation
     const n = Object.assign({}, node);

--- a/src/utils/mdast-to-vdom.js
+++ b/src/utils/mdast-to-vdom.js
@@ -18,6 +18,7 @@ const hast2html = require('hast-util-to-html');
 const unified = require('unified');
 const parse = require('rehype-parse');
 const { JSDOM } = require('jsdom');
+const heading = require('./heading-handler');
 const image = require('./image-handler');
 const embed = require('./embed-handler');
 const link = require('./link-handler');
@@ -60,6 +61,7 @@ class VDOMTransformer {
       this._handlers[type] = (cb, node, parent) => VDOMTransformer.handle(cb, node, parent, that);
       return true;
     });
+    this.match('heading', heading(options));
     this.match('image', image(options));
     this.match('embed', embed(options));
     this.match('link', link(options));

--- a/test/testGenerateHtmlId.js
+++ b/test/testGenerateHtmlId.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+const assert = require('assert');
+const check = require('../src/utils/generate-html-id');
+
+describe('Test generate-html-id', () => {
+  it('returns the lowercase version of the provided text', () => {
+    assert.equal('foo', check.generateId('foo'));
+    assert.equal('bar', check.generateId('Bar'));
+    assert.equal('baz', check.generateId('bAz'));
+    assert.equal('qux', check.generateId('quX'));
+  });
+
+  it('replaces white spaces with a simple dash', () => {
+    assert.equal('foo-bar', check.generateId('foo bar'));
+  });
+
+  it('removes special characters', () => {
+    assert.equal('foo', check.generateId('foo!'));
+    assert.equal('bar', check.generateId('=bar'));
+    assert.equal('baz', check.generateId('ba?z'));
+  });
+
+  it('supports accented characters', () => {
+    assert.equal('fòó', check.generateId('fòó'));
+    assert.equal('bär', check.generateId('bär'));
+    assert.equal('bâz', check.generateId('bâz'));
+    assert.equal('qũx', check.generateId('qũx'));
+    assert.equal('çŏrgę', check.generateId('çŏrgę'));
+  });
+
+  it('supports unicode foreign scripts', () => {
+    assert.equal('汉字-漢字', check.generateId('汉字 漢字'));
+    assert.equal('العربية', check.generateId('العربية'));
+    assert.equal('кириллица', check.generateId('кириллица'));
+    assert.equal('かな-カナ', check.generateId('かな カナ'));
+    assert.equal('한글-조선글', check.generateId('한글 조선글'));
+    assert.equal('ελληνικό', check.generateId('ελληνικό'));
+  });
+});

--- a/test/testMdastToVDOM.js
+++ b/test/testMdastToVDOM.js
@@ -39,7 +39,7 @@ const assertTransformerYieldsDocument = (transformer, expected) => {
   );
 };
 
-describe.only('Test MDAST to VDOM Transformation', () => {
+describe('Test MDAST to VDOM Transformation', () => {
   before('Coerce defaults', async () => {
     await coerce(action);
   });

--- a/test/testMdastToVDOM.js
+++ b/test/testMdastToVDOM.js
@@ -52,6 +52,21 @@ describe('Test MDAST to VDOM Transformation', () => {
     );
   });
 
+  it('Sections MDAST Conversion', () => {
+    const mdast = fs.readJSONSync(path.resolve(__dirname, 'fixtures', 'headings.json'));
+    assertTransformerYieldsDocument(
+      new VDOM(mdast, action.secrets), `
+      <h1 id="heading-1-double-underline">Heading 1 (double-underline)</h1>
+      <h2 id="heading-1-double-underline--heading-2-single-underline">Heading 2 (single-underline)</h2>
+      <h1 id="heading-1">Heading 1</h1>
+      <h2 id="heading-1--heading-2">Heading 2</h2>
+      <h3 id="heading-1--heading-2--heading-3">Heading 3</h3>
+      <h4 id="heading-1--heading-2--heading-3--heading-4">Heading 4</h4>
+      <h5 id="heading-1--heading-2--heading-3--heading-4--heading-5">Heading 5</h5>
+      <h6 id="heading-1--heading-2--heading-3--heading-4--heading-5--heading-6">Heading 6</h6>`,
+    );
+  });
+
   it('Custom Text Matcher Conversion', () => {
     const mdast = fs.readJSONSync(path.resolve(__dirname, 'fixtures', 'simple.json'));
     const transformer = new VDOM(mdast, action.secrets);

--- a/test/testMdastToVDOM.js
+++ b/test/testMdastToVDOM.js
@@ -57,13 +57,13 @@ describe('Test MDAST to VDOM Transformation', () => {
     assertTransformerYieldsDocument(
       new VDOM(mdast, action.secrets), `
       <h1 id="heading-1-double-underline">Heading 1 (double-underline)</h1>
-      <h2 id="heading-1-double-underline--heading-2-single-underline">Heading 2 (single-underline)</h2>
+      <h2 id="heading-2-single-underline">Heading 2 (single-underline)</h2>
       <h1 id="heading-1">Heading 1</h1>
-      <h2 id="heading-1--heading-2">Heading 2</h2>
-      <h3 id="heading-1--heading-2--heading-3">Heading 3</h3>
-      <h4 id="heading-1--heading-2--heading-3--heading-4">Heading 4</h4>
-      <h5 id="heading-1--heading-2--heading-3--heading-4--heading-5">Heading 5</h5>
-      <h6 id="heading-1--heading-2--heading-3--heading-4--heading-5--heading-6">Heading 6</h6>`,
+      <h2 id="heading-2">Heading 2</h2>
+      <h3 id="heading-3">Heading 3</h3>
+      <h4 id="heading-4">Heading 4</h4>
+      <h5 id="heading-5">Heading 5</h5>
+      <h6 id="heading-6">Heading 6</h6>`,
     );
   });
 

--- a/test/testMdastToVDOM.js
+++ b/test/testMdastToVDOM.js
@@ -39,7 +39,7 @@ const assertTransformerYieldsDocument = (transformer, expected) => {
   );
 };
 
-describe('Test MDAST to VDOM Transformation', () => {
+describe.only('Test MDAST to VDOM Transformation', () => {
   before('Coerce defaults', async () => {
     await coerce(action);
   });
@@ -48,7 +48,7 @@ describe('Test MDAST to VDOM Transformation', () => {
     const mdast = fs.readJSONSync(path.resolve(__dirname, 'fixtures', 'simple.json'));
     assertTransformerYieldsDocument(
       new VDOM(mdast, action.secrets),
-      '<h1>Hello World</h1>',
+      '<h1 id="hello-world">Hello World</h1>',
     );
   });
 


### PR DESCRIPTION
- Add a new `generate-html-id` util that leverages newly added `xregexp` module
- Add unit tests for the util
- Introduce `heading-handler` in the `mdast-to-vdom`
- Adapt existing unit tests to support the heading identifier