### PR TITLE
 feat(logs): Make context dump subdirectory names be more meaningful

### DIFF
--- a/src/utils/dump-context.js
+++ b/src/utils/dump-context.js
@@ -38,7 +38,7 @@ async function dump(context, action, index) {
   action.debug = action.debug || {};
   if (!action.debug.dumpDir) {
     const id = (context.request && context.request.headers && context.request.headers['x-openwhisk-activation-id']) || '';
-    const pathStr = context.request.path.replace(/\//g, '-').substring(1);
+    const pathStr = context.request && context.request.path ? context.request.path.replace(/\//g, '-').substring(1) : '';
     const dirName = `context_dump_${pathStr}_${nowStr}_${id}`;
     // eslint-disable-next-line no-param-reassign
     action.debug.dumpDir = path.resolve(process.cwd(), 'logs', 'debug', dirName);

--- a/src/utils/dump-context.js
+++ b/src/utils/dump-context.js
@@ -38,7 +38,8 @@ async function dump(context, action, index) {
   action.debug = action.debug || {};
   if (!action.debug.dumpDir) {
     const id = (context.request && context.request.headers && context.request.headers['x-openwhisk-activation-id']) || '';
-    const dirName = `context_dump_${nowStr}_${id}`;
+    const pathStr = context.request.path.replace(/\//g, '-').substring(1);
+    const dirName = `context_dump_${pathStr}_${nowStr}_${id}`;
     // eslint-disable-next-line no-param-reassign
     action.debug.dumpDir = path.resolve(process.cwd(), 'logs', 'debug', dirName);
     await fs.ensureDir(action.debug.dumpDir);

--- a/src/utils/dump-context.js
+++ b/src/utils/dump-context.js
@@ -39,7 +39,7 @@ async function dump(context, action, index) {
   if (!action.debug.dumpDir) {
     const id = (context.request && context.request.headers && context.request.headers['x-openwhisk-activation-id']) || '';
     const pathStr = context.request && context.request.path ? context.request.path.replace(/\//g, '-').substring(1) : '';
-    const dirName = `context_dump_${pathStr}_${nowStr}_${id}`;
+    const dirName = `context_dump_${nowStr}_${pathStr}_${id}`;
     // eslint-disable-next-line no-param-reassign
     action.debug.dumpDir = path.resolve(process.cwd(), 'logs', 'debug', dirName);
     await fs.ensureDir(action.debug.dumpDir);


### PR DESCRIPTION
PR for #248

Added the request path inside the folder name (slashes replaced by dashes).

For the following set of requests (in this order):

1. http://localhost:3000/index.html
1. http://localhost:3000/docs/ROLLOUT.html
1. http://localhost:3000/xd/doc/README.html
1. http://localhost:3000/index.html?debug=true

`ls -tl` will show the following "context dump" folders:

```
drwxr-xr-x  19 alex  staff  608 Apr 10 10:14 context_dump_index.default.html_20190310-0814-17.0133_741d12cbea5472965d966dbc5e75d3dc
drwxr-xr-x  19 alex  staff  608 Apr 10 10:14 context_dump_index.html_20190310-0814-16.0591_2dafb5fbea54ff17bfbf18c472da736e
drwxr-xr-x   4 alex  staff  128 Apr 10 10:14 context_dump_xd-doc-README.html_20190310-0814-11.0171_d5eb823d59694513aad62dcddf715647
drwxr-xr-x  19 alex  staff  608 Apr 10 10:14 context_dump_docs-ROLLOUT.default.html_20190310-0814-08.0245_9d3e9c8c91400844b336d34d0b2f5ef8
drwxr-xr-x  19 alex  staff  608 Apr 10 10:14 context_dump_docs-ROLLOUT.html_20190310-0814-07.0167_b83e7905c248c49dcd8de4d026a6ba41
drwxr-xr-x  19 alex  staff  608 Apr 10 10:13 context_dump_index.default.html_20190310-0813-54.0728_79d3de3d4381ca9fa3f40943db07f50b
drwxr-xr-x  19 alex  staff  608 Apr 10 10:13 context_dump_index.html_20190310-0813-53.0840_f5e4ebdb1d0d0749f33a4b7229a1acc3
```