### PR TITLE
feat(html pipe): Default pipeline should include <section/>s

### DIFF
--- a/2images.json
+++ b/2images.json
@@ -1,14 +1,4 @@
 {
-  "title": "helix-logo\nhelix-logo",
-  "image": "./helix_logo.png",
-  "intro": "helix-logo\nhelix-logo",
-  "meta": {
-    "types": [
-      "has-image",
-      "nb-image-2",
-      "has-only-image"
-    ]
-  },
   "type": "root",
   "children": [
     {
@@ -37,5 +27,15 @@
         ]
       }
     }
-  ]
+  ],
+  "meta": {
+    "types": [
+      "has-image",
+      "nb-image-2",
+      "has-only-image"
+    ]
+  },
+  "title": "helix-logo\nhelix-logo",
+  "intro": "helix-logo\nhelix-logo",
+  "image": "./helix_logo.png"
 }

--- a/complex.json
+++ b/complex.json
@@ -2,23 +2,6 @@
   "type": "root",
   "children": [
     {
-      "image": "https://img.shields.io/codecov/c/github/adobe/hypermedia-pipeline.svg",
-      "intro": "This project provides helper functions and default implementations for creating Hypermedia Processing Pipelines.",
-      "title": "Hypermedia Pipeline",
-      "meta": {
-        "title": "foo",
-        "types": [
-          "has-link",
-          "has-text",
-          "has-heading",
-          "nb-link-6",
-          "nb-text-3",
-          "nb-heading-2",
-          "is-link-text-heading",
-          "is-link-text",
-          "is-link"
-        ]
-      },
       "type": "section",
       "children": [
         {
@@ -197,27 +180,26 @@
             ]
           }
         }
-      ]
-    },
-    {
-      "intro": "A pipeline consists of following main parts:",
-      "title": "Anatomy of a Pipeline",
+      ],
       "meta": {
-        "class": "section",
+        "title": "foo",
         "types": [
+          "has-link",
           "has-text",
-          "has-inlineCode",
-          "has-list",
           "has-heading",
-          "nb-text-4",
-          "nb-inlineCode-2",
-          "nb-list-1",
-          "nb-heading-1",
-          "is-text-inlineCode-list",
-          "is-text-inlineCode",
-          "is-text"
+          "nb-link-6",
+          "nb-text-3",
+          "nb-heading-2",
+          "is-link-text-heading",
+          "is-link-text",
+          "is-link"
         ]
       },
+      "title": "Hypermedia Pipeline",
+      "intro": "This project provides helper functions and default implementations for creating Hypermedia Processing Pipelines.",
+      "image": "https://img.shields.io/codecov/c/github/adobe/hypermedia-pipeline.svg"
+    },
+    {
       "type": "section",
       "children": [
         {
@@ -389,18 +371,27 @@
             ]
           }
         }
-      ]
-    },
-    {
-      "title": "This section has a paragraph, but no title.",
-      "intro": "This section has a paragraph, but no title.",
+      ],
       "meta": {
+        "class": "section",
         "types": [
           "has-text",
-          "nb-text-2",
-          "has-only-text"
-        ]  
+          "has-inlineCode",
+          "has-list",
+          "has-heading",
+          "nb-text-4",
+          "nb-inlineCode-2",
+          "nb-list-1",
+          "nb-heading-1",
+          "is-text-inlineCode-list",
+          "is-text-inlineCode",
+          "is-text"
+        ]
       },
+      "title": "Anatomy of a Pipeline",
+      "intro": "A pipeline consists of following main parts:"
+    },
+    {
       "type": "section",
       "children": [
         {
@@ -431,18 +422,18 @@
             ]
           }
         }
-      ]
-    },
-    {
-      "intro": "This section has a title, but no paragraph",
-      "title": "This section has a title, but no paragraph",
+      ],
       "meta": {
         "types": [
-          "has-heading",
-          "nb-heading-1",
-          "has-only-heading"
-        ]  
+          "has-text",
+          "nb-text-2",
+          "has-only-text"
+        ]
       },
+      "title": "This section has a paragraph, but no title.",
+      "intro": "This section has a paragraph, but no title."
+    },
+    {
       "type": "section",
       "children": [
         {
@@ -460,21 +451,18 @@
             ]
           }
         }
-      ]
-    },
-    {
-      "title": "See below for the anatomy of a payload.",
-      "intro": "See below for the anatomy of a payload.",
+      ],
       "meta": {
         "types": [
-          "has-list",
-          "has-text",
-          "nb-list-1",
-          "nb-text-2",
-          "is-text-list",
-          "is-text"
-        ]  
+          "has-heading",
+          "nb-heading-1",
+          "has-only-heading"
+        ]
       },
+      "title": "This section has a title, but no paragraph",
+      "intro": "This section has a title, but no paragraph"
+    },
+    {
       "type": "section",
       "children": [
         {
@@ -592,29 +580,21 @@
             ]
           }
         }
-      ]
-    },
-    {
-      "intro": "A pipeline builder can be created by creating a CommonJS module that exports a function pipe which accepts following arguments and returns a Pipeline function.",
-      "title": "Building a Pipeline",
+      ],
       "meta": {
-        "class": "code",
         "types": [
-          "has-text",
-          "has-inlineCode",
-          "has-code",
           "has-list",
-          "has-heading",
-          "nb-text-6",
-          "nb-inlineCode-3",
-          "nb-code-1",
+          "has-text",
           "nb-list-1",
-          "nb-heading-1",
-          "is-text-inlineCode-code",
-          "is-text-inlineCode",
+          "nb-text-2",
+          "is-text-list",
           "is-text"
         ]
       },
+      "title": "See below for the anatomy of a payload.",
+      "intro": "See below for the anatomy of a payload."
+    },
+    {
       "type": "section",
       "children": [
         {
@@ -831,12 +811,12 @@
         {
           "type": "code",
           "lang": "javascript",
-          "value": "// the pipeline itself\nconst pipeline = require(\"@adobe/hypermedia-pipeline\");\n// helper functions and log\nconst { adaptOWRequest, adaptOWResponse, log } = require('@adobe/hypermedia-pipeline/src/defaults/default.js');\n\nmodule.exports.pipe = function(cont, params, secrets, logger = log) {\n    logger.log(\"debug\", \"Constructing Custom Pipeline\");\n\n    return pipeline()\n        .pre(adaptOWRequest)   // optional: turns OpenWhisk-style arguments into a proper payload\n        .once(cont)            // required: execute the continuation function\n        .post(adaptOWResponse) // optional: turns the Payload into an OpenWhisk-style response\n}",
           "meta": {
             "types": [
               "is-code"
             ]
-          }
+          },
+          "value": "// the pipeline itself\nconst pipeline = require(\"@adobe/hypermedia-pipeline\");\n// helper functions and log\nconst { adaptOWRequest, adaptOWResponse, log } = require('@adobe/hypermedia-pipeline/src/defaults/default.js');\n\nmodule.exports.pipe = function(cont, params, secrets, logger = log) {\n    logger.log(\"debug\", \"Constructing Custom Pipeline\");\n\n    return pipeline()\n        .pre(adaptOWRequest)   // optional: turns OpenWhisk-style arguments into a proper payload\n        .once(cont)            // required: execute the continuation function\n        .post(adaptOWResponse) // optional: turns the Payload into an OpenWhisk-style response\n}"
         },
         {
           "type": "paragraph",
@@ -869,28 +849,29 @@
             ]
           }
         }
-      ]
-    },
-    {
-      "intro": "The main function is typically a pure function that converts the request, context, and content properties of the payload into a response object.",
-      "title": "The Main Function",
+      ],
       "meta": {
+        "class": "code",
         "types": [
-          "has-list",
           "has-text",
           "has-inlineCode",
-          "has-heading",
           "has-code",
-          "nb-list-9",
-          "nb-text-25",
-          "nb-inlineCode-11",
-          "nb-heading-10",
+          "has-list",
+          "has-heading",
+          "nb-text-6",
+          "nb-inlineCode-3",
           "nb-code-1",
-          "is-text-inlineCode-heading",
+          "nb-list-1",
+          "nb-heading-1",
+          "is-text-inlineCode-code",
           "is-text-inlineCode",
           "is-text"
         ]
       },
+      "title": "Building a Pipeline",
+      "intro": "A pipeline builder can be created by creating a CommonJS module that exports a function pipe which accepts following arguments and returns a Pipeline function."
+    },
+    {
       "type": "section",
       "children": [
         {
@@ -1300,12 +1281,12 @@
         {
           "type": "code",
           "lang": "javascript",
-          "value": "// All wrapper functions must export `pre`\n// The functions takes following arguments:\n// - `cont` (the continuation function, i.e. the main template function)\n// - `payload` (the payload of the pipeline)\nmodule.exports.pre = (cont, payload) => {\n    const {request, content, context, response} = payload;\n    \n    // modifying the payload content before invoking the main function\n    content.hello = 'World';\n    const modifiedpayload = {request, content, context, response};\n\n    // invoking the main function with the new payload. Capturing the response\n    // payload for further modification\n\n    const responsepayload = cont(modifiedpayload);\n\n    // Adding a value to the payload response\n    const modifiedresponse = modifiedpayload.response;\n    modifiedresponse.hello = 'World';\n\n    return Object.assign(modifiedpayload, modifiedresponse);\n}",
           "meta": {
             "types": [
               "is-code"
             ]
-          }
+          },
+          "value": "// All wrapper functions must export `pre`\n// The functions takes following arguments:\n// - `cont` (the continuation function, i.e. the main template function)\n// - `payload` (the payload of the pipeline)\nmodule.exports.pre = (cont, payload) => {\n    const {request, content, context, response} = payload;\n    \n    // modifying the payload content before invoking the main function\n    content.hello = 'World';\n    const modifiedpayload = {request, content, context, response};\n\n    // invoking the main function with the new payload. Capturing the response\n    // payload for further modification\n\n    const responsepayload = cont(modifiedpayload);\n\n    // Adding a value to the payload response\n    const modifiedresponse = modifiedpayload.response;\n    modifiedresponse.hello = 'World';\n\n    return Object.assign(modifiedpayload, modifiedresponse);\n}"
         },
         {
           "type": "heading",
@@ -2355,7 +2336,26 @@
             ]
           }
         }
-      ]
+      ],
+      "meta": {
+        "types": [
+          "has-list",
+          "has-text",
+          "has-inlineCode",
+          "has-heading",
+          "has-code",
+          "nb-list-9",
+          "nb-text-25",
+          "nb-inlineCode-11",
+          "nb-heading-10",
+          "nb-code-1",
+          "is-text-inlineCode-heading",
+          "is-text-inlineCode",
+          "is-text"
+        ]
+      },
+      "title": "The Main Function",
+      "intro": "The main function is typically a pure function that converts the request, context, and content properties of the payload into a response object."
     }
   ]
 }

--- a/docs/content.schema.json
+++ b/docs/content.schema.json
@@ -46,7 +46,7 @@
             "description": "The XML object to emit. See xmlbuilder-js for syntax."
         },
         "meta": {
-            "$ref": "https://ns.adobe.com/helix/pipeline/meta#/definitions/meta/properties/meta"
+            "$ref": "https://ns.adobe.com/helix/pipeline/meta#/definitions/meta"
         },
         "title": {
             "$ref": "https://ns.adobe.com/helix/pipeline/meta#/definitions/meta/properties/title"

--- a/docs/content.schema.json
+++ b/docs/content.schema.json
@@ -33,13 +33,6 @@
         "mdast": {
             "$ref": "https://ns.adobe.com/helix/pipeline/mdast"
         },
-        "sections": {
-            "type": "array",
-            "description": "The extracted sections of the document",
-            "items": {
-                "$ref": "https://ns.adobe.com/helix/pipeline/section"
-            }
-        },
         "document": {
             "type": "object",
             "description": "The DOM-compatible representation of the document's inner HTML"

--- a/docs/content.schema.md
+++ b/docs/content.schema.md
@@ -29,7 +29,6 @@ The content as retrieved from the repository and enriched in the pipeline.
 | [json](#json) | `object` | Optional  | No | Content (this schema) |
 | [mdast](#mdast) | MDAST | Optional  | No | Content (this schema) |
 | [meta](#meta) | `object` | Optional  | No | Content (this schema) |
-| [sections](#sections) | Section | Optional  | No | Content (this schema) |
 | [sources](#sources) | `string[]` | Optional  | No | Content (this schema) |
 | [title](#title) | `string` | Optional  | No | Content (this schema) |
 | [xml](#xml) | `object` | Optional  | No | Content (this schema) |
@@ -206,31 +205,6 @@ Extracted metadata from the frontmatter of the document
 
 | Property | Type | Required |
 |----------|------|----------|
-
-
-
-
-
-
-## sections
-
-The extracted sections of the document
-
-`sections`
-
-* is optional
-* type: Section
-* defined in this schema
-
-### sections Type
-
-
-Array type: Section
-
-All items must be of the type:
-* [Section](section.schema.md) – `https://ns.adobe.com/helix/pipeline/section`
-
-
 
 
 

--- a/docs/content.schema.md
+++ b/docs/content.schema.md
@@ -28,7 +28,7 @@ The content as retrieved from the repository and enriched in the pipeline.
 | [intro](#intro) | `string` | Optional  | No | Content (this schema) |
 | [json](#json) | `object` | Optional  | No | Content (this schema) |
 | [mdast](#mdast) | MDAST | Optional  | No | Content (this schema) |
-| [meta](#meta) | `object` | Optional  | No | Content (this schema) |
+| [meta](#meta) | `object` | Optional  | Yes | Content (this schema) |
 | [sources](#sources) | `string[]` | Optional  | No | Content (this schema) |
 | [title](#title) | `string` | Optional  | No | Content (this schema) |
 | [xml](#xml) | `object` | Optional  | No | Content (this schema) |
@@ -189,7 +189,6 @@ The JSON object to emit.
 
 ## meta
 
-Extracted metadata from the frontmatter of the document
 
 `meta`
 
@@ -200,11 +199,169 @@ Extracted metadata from the frontmatter of the document
 ### meta Type
 
 
-`object` with following properties:
+`object`, nullable, with following properties:
 
 
 | Property | Type | Required |
 |----------|------|----------|
+| `class`| string | Optional |
+| `image`| string | Optional |
+| `intro`| string | Optional |
+| `meta`| boolean | Optional |
+| `tagname`| string | Optional |
+| `title`| string | Optional |
+| `types`| boolean | Optional |
+
+
+
+#### class
+
+The CSS class to use for the section instead of the default `hlx-section` one
+
+`class`
+
+* is optional
+* type: `string`
+
+##### class Type
+
+
+`string`
+
+
+
+
+
+
+
+
+
+#### image
+
+Path (can be relative) to the first image in the document
+
+`image`
+
+* is optional
+* type: `string`
+
+##### image Type
+
+
+`string`
+
+* format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
+
+
+
+
+
+
+
+
+#### intro
+
+Extracted first paragraph of the document
+
+`intro`
+
+* is optional
+* type: `string`
+
+##### intro Type
+
+
+`string`
+
+
+
+
+
+
+
+
+
+#### meta
+
+When set to `true`, will output the additional meta properties as data attributes (i.e. `'foo = bar'` will become `data-hlx-foo='bar'`)
+
+`meta`
+
+* is optional
+* type: `boolean`
+
+##### meta Type
+
+
+`boolean`
+
+
+
+
+
+
+
+#### tagname
+
+The element tag name to use for the section instead of the default `div` one (i.e. `section`, `main`, `aside`)
+
+`tagname`
+
+* is optional
+* type: `string`
+
+##### tagname Type
+
+
+`string`
+
+
+
+
+
+
+
+
+
+#### title
+
+Extracted title of the document
+
+`title`
+
+* is optional
+* type: `string`
+
+##### title Type
+
+
+`string`
+
+
+
+
+
+
+
+
+
+#### types
+
+When set to `true`, will output the section types as additional CSS classes (i.e. `class='hlx-section has-image has-heading'`)
+
+`types`
+
+* is optional
+* type: `boolean`
+
+##### types Type
+
+
+`boolean`
+
+
+
+
 
 
 

--- a/docs/content.schema.md
+++ b/docs/content.schema.md
@@ -207,10 +207,9 @@ The JSON object to emit.
 | `class`| string | Optional |
 | `image`| string | Optional |
 | `intro`| string | Optional |
-| `meta`| boolean | Optional |
 | `tagname`| string | Optional |
 | `title`| string | Optional |
-| `types`| boolean | Optional |
+| `types`| array | Optional |
 
 
 
@@ -281,26 +280,6 @@ Extracted first paragraph of the document
 
 
 
-#### meta
-
-When set to `true`, will output the additional meta properties as data attributes (i.e. `'foo = bar'` will become `data-hlx-foo='bar'`)
-
-`meta`
-
-* is optional
-* type: `boolean`
-
-##### meta Type
-
-
-`boolean`
-
-
-
-
-
-
-
 #### tagname
 
 The element tag name to use for the section instead of the default `div` one (i.e. `section`, `main`, `aside`)
@@ -347,17 +326,26 @@ Extracted title of the document
 
 #### types
 
-When set to `true`, will output the section types as additional CSS classes (i.e. `class='hlx-section has-image has-heading'`)
+The inferred class names for the section
 
 `types`
 
 * is optional
-* type: `boolean`
+* type: `string[]`
+
 
 ##### types Type
 
 
-`boolean`
+Array type: `string[]`
+
+All items must be of the type:
+`string`
+
+
+
+
+
 
 
 

--- a/docs/mdast.schema.json
+++ b/docs/mdast.schema.json
@@ -84,14 +84,16 @@
         },
         "children": {
             "type": "array",
-            "oneOf": [
-                {
-                    "$ref": "https://ns.adobe.com/helix/pipeline/mdast"
-                },
-                {
-                    "$ref": "https://ns.adobe.com/helix/pipeline/section#/definitions/section"
-                }
-            ]
+            "items": {
+                "oneOf": [
+                    {
+                        "$ref": "https://ns.adobe.com/helix/pipeline/mdast"
+                    },
+                    {
+                        "$ref": "https://ns.adobe.com/helix/pipeline/section#/definitions/section"
+                    }
+                ]
+            }
         },
         "position": {
             "$ref": "https://ns.adobe.com/helix/pipeline/position"
@@ -158,13 +160,6 @@
             ],
             "description": "For code, a lang field can be present. It represents the language of computer code being marked up."
         },
-        "meta": {
-            "type": [
-                "null",
-                "string"
-            ],
-            "description": "For code, if lang is present, a meta field can be present. It represents custom information relating to the node."
-        },
         "identifier": {
             "type": "string",
             "description": "For associations, an identifier field must be present. It can match an identifier field on another node."
@@ -178,12 +173,41 @@
             "format": "uri-reference",
             "description": "For resources, an url field must be present. It represents a URL to the referenced resource."
         },
+        "meta": {
+            "type": [
+                "null",
+                "object"
+            ],
+            "description": "Extracted metadata from the frontmatter of the document"
+        },
         "title": {
             "type": [
-                "string",
-                "null"
+                "null",
+                "string"
             ],
-            "description": "For resources, a title field can be present. It represents advisory information for the resource, such as would be appropriate for a tooltip."
+            "description": "Extracted title of the document"
+        },
+        "intro": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "description": "Extracted first paragraph of the document"
+        },
+        "image": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "uri-reference",
+            "description": "Path (can be relative) to the first image in the document"
+        },
+        "types": {
+            "type": "array",
+            "description": "The inferred class names for the section",
+            "items": {
+                "type": "string"
+            }
         },
         "alt": {
             "type": [

--- a/docs/mdast.schema.json
+++ b/docs/mdast.schema.json
@@ -47,7 +47,8 @@
                 "imageReference",
                 "footnote",
                 "footnoteReference",
-                "embed"
+                "embed",
+                "section"
             ],
             "meta:enum": {
                 "root": "The root node, representing a document or section",
@@ -76,15 +77,21 @@
                 "imageReference": "A pointer to an image",
                 "footnote": "A footnote",
                 "footnoteReference": "A reference to a footnote",
-                "embed": "Content embedded from another page, identified by the `url` attribute."
+                "embed": "Content embedded from another page, identified by the `url` attribute.",
+                "section": "The extracted sections of the document"
             },
             "description": "The node type of the MDAST node"
         },
         "children": {
             "type": "array",
-            "items": {
-                "$ref": "https://ns.adobe.com/helix/pipeline/mdast"
-            }
+            "oneOf": [
+                {
+                    "$ref": "https://ns.adobe.com/helix/pipeline/mdast"
+                },
+                {
+                    "$ref": "https://ns.adobe.com/helix/pipeline/section#/definitions/section"
+                }
+            ]
         },
         "position": {
             "$ref": "https://ns.adobe.com/helix/pipeline/position"

--- a/docs/mdast.schema.json
+++ b/docs/mdast.schema.json
@@ -78,7 +78,7 @@
                 "footnote": "A footnote",
                 "footnoteReference": "A reference to a footnote",
                 "embed": "Content embedded from another page, identified by the `url` attribute.",
-                "section": "The extracted sections of the document"
+                "section": "A section within the document. Sections serve as a high-level structure of a single markdown document and can have their own section-specific front matter metadata."
             },
             "description": "The node type of the MDAST node"
         },

--- a/docs/mdast.schema.json
+++ b/docs/mdast.schema.json
@@ -174,11 +174,7 @@
             "description": "For resources, an url field must be present. It represents a URL to the referenced resource."
         },
         "meta": {
-            "type": [
-                "null",
-                "object"
-            ],
-            "description": "Extracted metadata from the frontmatter of the document"
+            "$ref": "https://ns.adobe.com/helix/pipeline/meta#/definitions/meta"
         },
         "title": {
             "type": [

--- a/docs/mdast.schema.md
+++ b/docs/mdast.schema.md
@@ -348,10 +348,9 @@ For code, a lang field can be present. It represents the language of computer co
 | `class`| string | Optional |
 | `image`| string | Optional |
 | `intro`| string | Optional |
-| `meta`| boolean | Optional |
 | `tagname`| string | Optional |
 | `title`| string | Optional |
-| `types`| boolean | Optional |
+| `types`| array | Optional |
 
 
 
@@ -422,26 +421,6 @@ Extracted first paragraph of the document
 
 
 
-#### meta
-
-When set to `true`, will output the additional meta properties as data attributes (i.e. `'foo = bar'` will become `data-hlx-foo='bar'`)
-
-`meta`
-
-* is optional
-* type: `boolean`
-
-##### meta Type
-
-
-`boolean`
-
-
-
-
-
-
-
 #### tagname
 
 The element tag name to use for the section instead of the default `div` one (i.e. `section`, `main`, `aside`)
@@ -488,17 +467,26 @@ Extracted title of the document
 
 #### types
 
-When set to `true`, will output the section types as additional CSS classes (i.e. `class='hlx-section has-image has-heading'`)
+The inferred class names for the section
 
 `types`
 
 * is optional
-* type: `boolean`
+* type: `string[]`
+
 
 ##### types Type
 
 
-`boolean`
+Array type: `string[]`
+
+All items must be of the type:
+`string`
+
+
+
+
+
 
 
 

--- a/docs/mdast.schema.md
+++ b/docs/mdast.schema.md
@@ -27,9 +27,11 @@ A node in the Markdown AST
 | [data](#data) | `object` | Optional  | No | MDAST (this schema) |
 | [depth](#depth) | `integer` | Optional  | No | MDAST (this schema) |
 | [identifier](#identifier) | `string` | Optional  | No | MDAST (this schema) |
+| [image](#image) | `string` | Optional  | Yes | MDAST (this schema) |
+| [intro](#intro) | `string` | Optional  | Yes | MDAST (this schema) |
 | [label](#label) | `string` | Optional  | No | MDAST (this schema) |
 | [lang](#lang) | `string` | Optional  | Yes | MDAST (this schema) |
-| [meta](#meta) | `string` | Optional  | Yes | MDAST (this schema) |
+| [meta](#meta) | `object` | Optional  | Yes | MDAST (this schema) |
 | [ordered](#ordered) | `boolean` | Optional  | No | MDAST (this schema) |
 | [payload](#payload) | `object` | Optional  | No | MDAST (this schema) |
 | [position](#position) | Position | Optional  | No | MDAST (this schema) |
@@ -38,6 +40,7 @@ A node in the Markdown AST
 | [start](#start) | `integer` | Optional  | Yes | MDAST (this schema) |
 | [title](#title) | `string` | Optional  | Yes | MDAST (this schema) |
 | [type](#type) | `enum` | Optional  | No | MDAST (this schema) |
+| [types](#types) | `string[]` | Optional  | No | MDAST (this schema) |
 | [url](#url) | `string` | Optional  | No | MDAST (this schema) |
 | [value](#value) | `string` | Optional  | No | MDAST (this schema) |
 
@@ -147,6 +150,26 @@ A checked field can be present. It represents whether the item is done (when tru
 
 Array type: `array`
 
+All items must be of the type:
+
+**One** of the following *conditions* need to be fulfilled.
+
+
+#### Condition 1
+
+
+* []() – `https://ns.adobe.com/helix/pipeline/mdast`
+
+
+#### Condition 2
+
+
+* []() – `https://ns.adobe.com/helix/pipeline/section#/definitions/section`
+
+
+  
+
+
 
 
 
@@ -219,6 +242,49 @@ For associations, an identifier field must be present. It can match an identifie
 
 
 
+## image
+
+Path (can be relative) to the first image in the document
+
+`image`
+
+* is optional
+* type: `string`
+* defined in this schema
+
+### image Type
+
+
+`string`, nullable
+
+* format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
+
+
+
+
+
+
+## intro
+
+Extracted first paragraph of the document
+
+`intro`
+
+* is optional
+* type: `string`
+* defined in this schema
+
+### intro Type
+
+
+`string`, nullable
+
+
+
+
+
+
+
 ## label
 
 For associations, a label field can be present. It represents the original value of the normalised identifier field.
@@ -263,19 +329,22 @@ For code, a lang field can be present. It represents the language of computer co
 
 ## meta
 
-For code, if lang is present, a meta field can be present. It represents custom information relating to the node.
+Extracted metadata from the frontmatter of the document
 
 `meta`
 
 * is optional
-* type: `string`
+* type: `object`
 * defined in this schema
 
 ### meta Type
 
 
-`string`, nullable
+`object`, nullable, with following properties:
 
+
+| Property | Type | Required |
+|----------|------|----------|
 
 
 
@@ -407,7 +476,7 @@ Starting item of the list
 
 ## title
 
-For resources, a title field can be present. It represents advisory information for the resource, such as would be appropriate for a tooltip.
+Extracted title of the document
 
 `title`
 
@@ -470,6 +539,33 @@ The value of this property **must** be equal to one of the [known values below](
 | `embed` | Content embedded from another page, identified by the `url` attribute. |
 | `section` | A section within the document. Sections serve as a high-level structure of a single markdown document and can have their own section-specific front matter metadata. |
 | `listItem` |  |
+
+
+
+
+## types
+
+The inferred class names for the section
+
+`types`
+
+* is optional
+* type: `string[]`
+* defined in this schema
+
+### types Type
+
+
+Array type: `string[]`
+
+All items must be of the type:
+`string`
+
+
+
+
+
+
 
 
 

--- a/docs/mdast.schema.md
+++ b/docs/mdast.schema.md
@@ -23,7 +23,7 @@ A node in the Markdown AST
 | [align](#align) | `enum[]` | Optional  | No | MDAST (this schema) |
 | [alt](#alt) | `string` | Optional  | Yes | MDAST (this schema) |
 | [checked](#checked) | `boolean` | Optional  | Yes | MDAST (this schema) |
-| [children](#children) | MDAST | Optional  | No | MDAST (this schema) |
+| [children](#children) | `array` | Optional  | No | MDAST (this schema) |
 | [data](#data) | `object` | Optional  | No | MDAST (this schema) |
 | [depth](#depth) | `integer` | Optional  | No | MDAST (this schema) |
 | [identifier](#identifier) | `string` | Optional  | No | MDAST (this schema) |
@@ -139,18 +139,13 @@ A checked field can be present. It represents whether the item is done (when tru
 `children`
 
 * is optional
-* type: MDAST
+* type: `array`
 * defined in this schema
 
 ### children Type
 
 
-Array type: MDAST
-
-All items must be of the type:
-* [MDAST](mdast.schema.md) – `https://ns.adobe.com/helix/pipeline/mdast`
-
-
+Array type: `array`
 
 
 
@@ -473,6 +468,7 @@ The value of this property **must** be equal to one of the [known values below](
 | `footnote` | A footnote |
 | `footnoteReference` | A reference to a footnote |
 | `embed` | Content embedded from another page, identified by the `url` attribute. |
+| `section` | A section within the document. Sections serve as a high-level structure of a single markdown document and can have their own section-specific front matter metadata. |
 | `listItem` |  |
 
 

--- a/docs/mdast.schema.md
+++ b/docs/mdast.schema.md
@@ -14,6 +14,7 @@ A node in the Markdown AST
 
 * MDAST `https://ns.adobe.com/helix/pipeline/mdast`
   * [Position](position.schema.md) `https://ns.adobe.com/helix/pipeline/position`
+  * [Meta](meta.schema.md) `https://ns.adobe.com/helix/pipeline/meta`
 
 
 # MDAST Properties
@@ -329,7 +330,6 @@ For code, a lang field can be present. It represents the language of computer co
 
 ## meta
 
-Extracted metadata from the frontmatter of the document
 
 `meta`
 
@@ -345,6 +345,164 @@ Extracted metadata from the frontmatter of the document
 
 | Property | Type | Required |
 |----------|------|----------|
+| `class`| string | Optional |
+| `image`| string | Optional |
+| `intro`| string | Optional |
+| `meta`| boolean | Optional |
+| `tagname`| string | Optional |
+| `title`| string | Optional |
+| `types`| boolean | Optional |
+
+
+
+#### class
+
+The CSS class to use for the section instead of the default `hlx-section` one
+
+`class`
+
+* is optional
+* type: `string`
+
+##### class Type
+
+
+`string`
+
+
+
+
+
+
+
+
+
+#### image
+
+Path (can be relative) to the first image in the document
+
+`image`
+
+* is optional
+* type: `string`
+
+##### image Type
+
+
+`string`
+
+* format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
+
+
+
+
+
+
+
+
+#### intro
+
+Extracted first paragraph of the document
+
+`intro`
+
+* is optional
+* type: `string`
+
+##### intro Type
+
+
+`string`
+
+
+
+
+
+
+
+
+
+#### meta
+
+When set to `true`, will output the additional meta properties as data attributes (i.e. `'foo = bar'` will become `data-hlx-foo='bar'`)
+
+`meta`
+
+* is optional
+* type: `boolean`
+
+##### meta Type
+
+
+`boolean`
+
+
+
+
+
+
+
+#### tagname
+
+The element tag name to use for the section instead of the default `div` one (i.e. `section`, `main`, `aside`)
+
+`tagname`
+
+* is optional
+* type: `string`
+
+##### tagname Type
+
+
+`string`
+
+
+
+
+
+
+
+
+
+#### title
+
+Extracted title of the document
+
+`title`
+
+* is optional
+* type: `string`
+
+##### title Type
+
+
+`string`
+
+
+
+
+
+
+
+
+
+#### types
+
+When set to `true`, will output the section types as additional CSS classes (i.e. `class='hlx-section has-image has-heading'`)
+
+`types`
+
+* is optional
+* type: `boolean`
+
+##### types Type
+
+
+`boolean`
+
+
+
+
 
 
 

--- a/docs/meta.schema.json
+++ b/docs/meta.schema.json
@@ -30,13 +30,12 @@
                     "type": "string",
                     "description": "The element tag name to use for the section instead of the default `div` one (i.e. `section`, `main`, `aside`)"
                 },
-                "meta": {
-                    "type": "boolean",
-                    "description": "When set to `true`, will output the additional meta properties as data attributes (i.e. `'foo = bar'` will become `data-hlx-foo='bar'`)"
-                },
                 "types": {
-                    "type": "boolean",
-                    "description": "When set to `true`, will output the section types as additional CSS classes (i.e. `class='hlx-section has-image has-heading'`)"
+                    "type": "array",
+                    "description": "The inferred class names for the section",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "title": {
                     "type": "string",

--- a/docs/meta.schema.json
+++ b/docs/meta.schema.json
@@ -17,10 +17,26 @@
     "description": "Content and Section Metadata Properties",
     "definitions": {
         "meta": {
+            "type": [
+                "null",
+                "object"
+            ],
             "properties": {
+                "class": {
+                    "type": "string",
+                    "description": "The CSS class to use for the section instead of the default `hlx-section` one"
+                },
+                "tagname": {
+                    "type": "string",
+                    "description": "The element tag name to use for the section instead of the default `div` one (i.e. `section`, `main`, `aside`)"
+                },
                 "meta": {
-                    "type": "object",
-                    "description": "Extracted metadata from the frontmatter of the document"
+                    "type": "boolean",
+                    "description": "When set to `true`, will output the additional meta properties as data attributes (i.e. `'foo = bar'` will become `data-hlx-foo='bar'`)"
+                },
+                "types": {
+                    "type": "boolean",
+                    "description": "When set to `true`, will output the section types as additional CSS classes (i.e. `class='hlx-section has-image has-heading'`)"
                 },
                 "title": {
                     "type": "string",

--- a/docs/meta.schema.md
+++ b/docs/meta.schema.md
@@ -18,10 +18,9 @@ Content and Section Metadata Properties
 | [class](#class) | `string` | `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta` |
 | [image](#image) | `string` | `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta` |
 | [intro](#intro) | `string` | `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta` |
-| [meta](#meta) | `boolean` | `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta` |
 | [tagname](#tagname) | `string` | `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta` |
 | [title](#title) | `string` | `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta` |
-| [types](#types) | `boolean` | `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta` |
+| [types](#types) | `string[]` | `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta` |
 
 ## class
 
@@ -87,25 +86,6 @@ Extracted first paragraph of the document
 
 
 
-## meta
-
-When set to `true`, will output the additional meta properties as data attributes (i.e. `'foo = bar'` will become `data-hlx-foo='bar'`)
-
-`meta`
-
-* is optional
-* type: `boolean`
-* defined in this schema
-
-### meta Type
-
-
-`boolean`
-
-
-
-
-
 ## tagname
 
 The element tag name to use for the section instead of the default `div` one (i.e. `section`, `main`, `aside`)
@@ -150,18 +130,26 @@ Extracted title of the document
 
 ## types
 
-When set to `true`, will output the section types as additional CSS classes (i.e. `class='hlx-section has-image has-heading'`)
+The inferred class names for the section
 
 `types`
 
 * is optional
-* type: `boolean`
+* type: `string[]`
 * defined in this schema
 
 ### types Type
 
 
-`boolean`
+Array type: `string[]`
+
+All items must be of the type:
+`string`
+
+
+
+
+
 
 
 

--- a/docs/meta.schema.md
+++ b/docs/meta.schema.md
@@ -15,10 +15,34 @@ Content and Section Metadata Properties
 
 | Property | Type | Group |
 |----------|------|-------|
+| [class](#class) | `string` | `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta` |
 | [image](#image) | `string` | `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta` |
 | [intro](#intro) | `string` | `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta` |
-| [meta](#meta) | `object` | `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta` |
+| [meta](#meta) | `boolean` | `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta` |
+| [tagname](#tagname) | `string` | `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta` |
 | [title](#title) | `string` | `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta` |
+| [types](#types) | `boolean` | `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta` |
+
+## class
+
+The CSS class to use for the section instead of the default `hlx-section` one
+
+`class`
+
+* is optional
+* type: `string`
+* defined in this schema
+
+### class Type
+
+
+`string`
+
+
+
+
+
+
 
 ## image
 
@@ -65,22 +89,38 @@ Extracted first paragraph of the document
 
 ## meta
 
-Extracted metadata from the frontmatter of the document
+When set to `true`, will output the additional meta properties as data attributes (i.e. `'foo = bar'` will become `data-hlx-foo='bar'`)
 
 `meta`
 
 * is optional
-* type: `object`
+* type: `boolean`
 * defined in this schema
 
 ### meta Type
 
 
-`object` with following properties:
+`boolean`
 
 
-| Property | Type | Required |
-|----------|------|----------|
+
+
+
+## tagname
+
+The element tag name to use for the section instead of the default `div` one (i.e. `section`, `main`, `aside`)
+
+`tagname`
+
+* is optional
+* type: `string`
+* defined in this schema
+
+### tagname Type
+
+
+`string`
+
 
 
 
@@ -103,6 +143,25 @@ Extracted title of the document
 `string`
 
 
+
+
+
+
+
+## types
+
+When set to `true`, will output the section types as additional CSS classes (i.e. `class='hlx-section has-image has-heading'`)
+
+`types`
+
+* is optional
+* type: `boolean`
+* defined in this schema
+
+### types Type
+
+
+`boolean`
 
 
 

--- a/docs/section.schema.json
+++ b/docs/section.schema.json
@@ -19,13 +19,6 @@
         "section": {
             "additionalProperties": false,
             "properties": {
-                "types": {
-                    "type": "array",
-                    "description": "The inferred class names for the section",
-                    "items": {
-                        "type": "string"
-                    }
-                },
                 "type": {
                     "const": "root",
                     "description": "The MDAST node type. Each section can be treated as a standalone document."
@@ -41,7 +34,7 @@
                     }
                 },
                 "meta": {
-                    "$ref": "https://ns.adobe.com/helix/pipeline/meta#/definitions/meta/properties/meta"
+                    "$ref": "https://ns.adobe.com/helix/pipeline/meta#/definitions/meta"
                 },
                 "title": {
                     "$ref": "https://ns.adobe.com/helix/pipeline/meta#/definitions/meta/properties/title"

--- a/docs/section.schema.json
+++ b/docs/section.schema.json
@@ -54,13 +54,5 @@
                 }
             }
         }
-    },
-    "allOf": [
-        {
-            "$ref": "#/definitions/section"
-        },
-        {
-            "$ref": "https://ns.adobe.com/helix/pipeline/meta#/definitions/meta"
-        }
-    ]
+    }
 }

--- a/docs/section.schema.md
+++ b/docs/section.schema.md
@@ -9,27 +9,20 @@ A section in a markdown document
 
 | Abstract | Extensible | Status | Identifiable | Custom Properties | Additional Properties | Defined In |
 |----------|------------|--------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | Yes | Experimental | No | Forbidden | Permitted | [section.schema.json](section.schema.json) |
-## Schema Hierarchy
+| Cannot be instantiated | Yes | Experimental | No | Forbidden | Permitted | [section.schema.json](section.schema.json) |
 
-* Section `https://ns.adobe.com/helix/pipeline/section`
-  * [Position](position.schema.md) `https://ns.adobe.com/helix/pipeline/position`
-  * [Meta](meta.schema.md) `https://ns.adobe.com/helix/pipeline/meta`
+# Section Definitions
 
-
-# Section Properties
-
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [children](#children) | MDAST | Optional  | No | Section (this schema) |
-| [image](#image) | `string` | Optional  | No | [Meta](meta.schema.md#image) |
-| [intro](#intro) | `string` | Optional  | No | [Meta](meta.schema.md#intro) |
-| [meta](#meta) | `object` | Optional  | No | [Meta](meta.schema.md#meta) |
-| [position](#position) | Position | Optional  | No | Section (this schema) |
-| [title](#title) | `string` | Optional  | No | [Meta](meta.schema.md#title) |
-| [type](#type) | `const` | Optional  | No | Section (this schema) |
-| [types](#types) | `string[]` | Optional  | No | Section (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property | Type | Group |
+|----------|------|-------|
+| [children](#children) | reference | `https://ns.adobe.com/helix/pipeline/section#/definitions/section` |
+| [image](#image) | reference | `https://ns.adobe.com/helix/pipeline/section#/definitions/section` |
+| [intro](#intro) | reference | `https://ns.adobe.com/helix/pipeline/section#/definitions/section` |
+| [meta](#meta) | reference | `https://ns.adobe.com/helix/pipeline/section#/definitions/section` |
+| [position](#position) | reference | `https://ns.adobe.com/helix/pipeline/section#/definitions/section` |
+| [title](#title) | reference | `https://ns.adobe.com/helix/pipeline/section#/definitions/section` |
+| [type](#type) | `const` | `https://ns.adobe.com/helix/pipeline/section#/definitions/section` |
+| [types](#types) | `string[]` | `https://ns.adobe.com/helix/pipeline/section#/definitions/section` |
 
 ## children
 
@@ -38,16 +31,16 @@ The AST nodes making up the section. Section dividers are not included.
 `children`
 
 * is optional
-* type: MDAST
+* type: reference
 * defined in this schema
 
 ### children Type
 
 
-Array type: MDAST
+Array type: reference
 
 All items must be of the type:
-* [MDAST](mdast.schema.md) – `https://ns.adobe.com/helix/pipeline/mdast`
+* []() – `https://ns.adobe.com/helix/pipeline/mdast`
 
 
 
@@ -58,21 +51,17 @@ All items must be of the type:
 
 ## image
 
-Path (can be relative) to the first image in the document
 
 `image`
 
 * is optional
-* type: `string`
-* defined in [Meta](meta.schema.md#image)
+* type: reference
+* defined in this schema
 
 ### image Type
 
 
-`string`
-
-* format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
-
+* []() – `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta/properties/image`
 
 
 
@@ -80,20 +69,17 @@ Path (can be relative) to the first image in the document
 
 ## intro
 
-Extracted first paragraph of the document
 
 `intro`
 
 * is optional
-* type: `string`
-* defined in [Meta](meta.schema.md#intro)
+* type: reference
+* defined in this schema
 
 ### intro Type
 
 
-`string`
-
-
+* []() – `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta/properties/intro`
 
 
 
@@ -101,23 +87,17 @@ Extracted first paragraph of the document
 
 ## meta
 
-Extracted metadata from the frontmatter of the document
 
 `meta`
 
 * is optional
-* type: `object`
-* defined in [Meta](meta.schema.md#meta)
+* type: reference
+* defined in this schema
 
 ### meta Type
 
 
-`object` with following properties:
-
-
-| Property | Type | Required |
-|----------|------|----------|
-
+* []() – `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta/properties/meta`
 
 
 
@@ -129,13 +109,13 @@ Extracted metadata from the frontmatter of the document
 `position`
 
 * is optional
-* type: Position
+* type: reference
 * defined in this schema
 
 ### position Type
 
 
-* [Position](position.schema.md) – `https://ns.adobe.com/helix/pipeline/position`
+* []() – `https://ns.adobe.com/helix/pipeline/position`
 
 
 
@@ -143,20 +123,17 @@ Extracted metadata from the frontmatter of the document
 
 ## title
 
-Extracted title of the document
 
 `title`
 
 * is optional
-* type: `string`
-* defined in [Meta](meta.schema.md#title)
+* type: reference
+* defined in this schema
 
 ### title Type
 
 
-`string`
-
-
+* []() – `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta/properties/title`
 
 
 
@@ -207,20 +184,4 @@ All items must be of the type:
 
 
 
-
-
-
-**All** of the following *requirements* need to be fulfilled.
-
-
-#### Requirement 1
-
-
-* []() – `#/definitions/section`
-
-
-#### Requirement 2
-
-
-* []() – `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta`
 

--- a/docs/section.schema.md
+++ b/docs/section.schema.md
@@ -22,7 +22,6 @@ A section in a markdown document
 | [position](#position) | reference | `https://ns.adobe.com/helix/pipeline/section#/definitions/section` |
 | [title](#title) | reference | `https://ns.adobe.com/helix/pipeline/section#/definitions/section` |
 | [type](#type) | `const` | `https://ns.adobe.com/helix/pipeline/section#/definitions/section` |
-| [types](#types) | `string[]` | `https://ns.adobe.com/helix/pipeline/section#/definitions/section` |
 
 ## children
 
@@ -97,7 +96,7 @@ All items must be of the type:
 ### meta Type
 
 
-* []() – `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta/properties/meta`
+* []() – `https://ns.adobe.com/helix/pipeline/meta#/definitions/meta`
 
 
 
@@ -154,33 +153,6 @@ The value of this property **must** be equal to:
 ```json
 "root"
 ```
-
-
-
-
-
-## types
-
-The inferred class names for the section
-
-`types`
-
-* is optional
-* type: `string[]`
-* defined in this schema
-
-### types Type
-
-
-Array type: `string[]`
-
-All items must be of the type:
-`string`
-
-
-
-
-
 
 
 

--- a/header.json
+++ b/header.json
@@ -1,13 +1,4 @@
 {
-  "intro": "Header only",
-  "title": "Header only",
-  "meta": {
-    "types": [
-      "has-heading",
-      "nb-heading-1",
-      "has-only-heading"
-    ]
-  },
   "type": "root",
   "children": [
     {
@@ -25,5 +16,14 @@
         ]
       }
     }
-  ]
+  ],
+  "meta": {
+    "types": [
+      "has-heading",
+      "nb-heading-1",
+      "has-only-heading"
+    ]
+  },
+  "title": "Header only",
+  "intro": "Header only"
 }

--- a/headerimage.json
+++ b/headerimage.json
@@ -1,17 +1,4 @@
 {
-  "intro": "Header and one image",
-  "image": "./helix_logo.png",
-  "title": "Header and one image",
-  "meta": {
-    "types": [
-      "has-image",
-      "has-heading",
-      "nb-image-1",
-      "nb-heading-1",
-      "is-image-heading",
-      "is-image"
-    ]
-  },
   "type": "root",
   "children": [
     {
@@ -45,5 +32,18 @@
         ]
       }
     }
-  ]
+  ],
+  "meta": {
+    "types": [
+      "has-image",
+      "has-heading",
+      "nb-image-1",
+      "nb-heading-1",
+      "is-image-heading",
+      "is-image"
+    ]
+  },
+  "title": "Header and one image",
+  "intro": "Header and one image",
+  "image": "./helix_logo.png"
 }

--- a/headerlist.json
+++ b/headerlist.json
@@ -1,16 +1,4 @@
 {
-  "intro": "list item 1",
-  "title": "Header and a list",
-  "meta": {
-    "types": [
-      "has-list",
-      "has-heading",
-      "nb-list-1",
-      "nb-heading-1",
-      "is-list-heading",
-      "is-list"
-    ]
-  },
   "type": "root",
   "children": [
     {
@@ -107,5 +95,17 @@
         ]
       }
     }
-  ]
+  ],
+  "meta": {
+    "types": [
+      "has-list",
+      "has-heading",
+      "nb-list-1",
+      "nb-heading-1",
+      "is-list-heading",
+      "is-list"
+    ]
+  },
+  "title": "Header and a list",
+  "intro": "list item 1"
 }

--- a/headerpara2images.json
+++ b/headerpara2images.json
@@ -1,20 +1,4 @@
 {
-  "image": "./helix_logo.png",
-  "intro": "This is a paragraph.",
-  "title": "Header, a paragraph and one image",
-  "meta": {
-    "types": [
-      "has-image",
-      "has-text",
-      "has-heading",
-      "nb-image-1",
-      "nb-text-1",
-      "nb-heading-1",
-      "is-image-text-heading",
-      "is-image-text",
-      "is-image"
-    ]
-  },
   "type": "root",
   "children": [
     {
@@ -54,6 +38,16 @@
           "title": null,
           "url": "./helix_logo.png",
           "alt": "helix-logo"
+        },
+        {
+          "type": "text",
+          "value": "\n"
+        },
+        {
+          "type": "image",
+          "title": null,
+          "url": "./helix_logo.png",
+          "alt": "helix-logo"
         }
       ],
       "meta": {
@@ -62,5 +56,21 @@
         ]
       }
     }
-  ]
+  ],
+  "meta": {
+    "types": [
+      "has-image",
+      "has-text",
+      "has-heading",
+      "nb-image-2",
+      "nb-text-1",
+      "nb-heading-1",
+      "is-image-text-heading",
+      "is-image-text",
+      "is-image"
+    ]
+  },
+  "title": "Header, a paragraph and one image",
+  "intro": "This is a paragraph.",
+  "image": "./helix_logo.png"
 }

--- a/headerparagraph.json
+++ b/headerparagraph.json
@@ -1,16 +1,4 @@
 {
-  "intro": "This is a paragraph.",
-  "title": "Header and one paragraph",
-  "meta": {
-    "types": [
-      "has-text",
-      "has-heading",
-      "nb-text-1",
-      "nb-heading-1",
-      "is-text-heading",
-      "is-text"
-    ]
-  },
   "type": "root",
   "children": [
     {
@@ -42,5 +30,17 @@
         ]
       }
     }
-  ]
+  ],
+  "meta": {
+    "types": [
+      "has-text",
+      "has-heading",
+      "nb-text-1",
+      "nb-heading-1",
+      "is-text-heading",
+      "is-text"
+    ]
+  },
+  "title": "Header and one paragraph",
+  "intro": "This is a paragraph."
 }

--- a/headerparaimage.json
+++ b/headerparaimage.json
@@ -1,20 +1,4 @@
 {
-  "image": "./helix_logo.png",
-  "intro": "This is a paragraph.",
-  "title": "Header, a paragraph and one image",
-  "meta": {
-    "types": [
-      "has-image",
-      "has-text",
-      "has-heading",
-      "nb-image-1",
-      "nb-text-1",
-      "nb-heading-1",
-      "is-image-text-heading",
-      "is-image-text",
-      "is-image"
-    ]
-  },
   "type": "root",
   "children": [
     {
@@ -62,5 +46,21 @@
         ]
       }
     }
-  ]
+  ],
+  "meta": {
+    "types": [
+      "has-image",
+      "has-text",
+      "has-heading",
+      "nb-image-1",
+      "nb-text-1",
+      "nb-heading-1",
+      "is-image-text-heading",
+      "is-image-text",
+      "is-image"
+    ]
+  },
+  "title": "Header, a paragraph and one image",
+  "intro": "This is a paragraph.",
+  "image": "./helix_logo.png"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/helix-pipeline",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4986,7 +4986,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
@@ -15730,7 +15730,7 @@
     },
     "yargs": {
       "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4156,6 +4156,14 @@
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
     },
+    "ferrum": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ferrum/-/ferrum-0.1.0.tgz",
+      "integrity": "sha512-RKFvJCgWTVozg13Xw62i6v9fNQivaePRCCOXa1G5qmDifBZJ7Nvv2KP7sPcTYbDSbN1YUdr6nYWlD3QP9OFyRA==",
+      "requires": {
+        "lodash": "4.17.11"
+      }
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "callsites": "^3.0.0",
     "clone": "^2.1.2",
     "dompurify": "^1.0.10",
+    "ferrum": "^0.1.0",
     "fs-extra": "^8.0.0",
     "github-slugger": "^1.2.1",
     "js-yaml": "^3.13.1",

--- a/paragraph.json
+++ b/paragraph.json
@@ -1,13 +1,4 @@
 {
-  "title": "This is only a paragraph.",
-  "intro": "This is only a paragraph.",
-  "meta": {
-    "types": [
-      "has-text",
-      "nb-text-1",
-      "has-only-text"
-    ]  
-  },
   "type": "root",
   "children": [
     {
@@ -24,5 +15,14 @@
         ]
       }
     }
-  ]
+  ],
+  "meta": {
+    "types": [
+      "has-text",
+      "nb-text-1",
+      "has-only-text"
+    ]
+  },
+  "title": "This is only a paragraph.",
+  "intro": "This is only a paragraph."
 }

--- a/paragraphwithlink.json
+++ b/paragraphwithlink.json
@@ -1,16 +1,4 @@
 {
-  "title": "This is a paragraph with a link!",
-  "intro": "This is a paragraph with a link!",
-  "meta": {
-    "types": [
-      "has-text",
-      "has-link",
-      "nb-text-2",
-      "nb-link-1",
-      "is-text-link",
-      "is-text"
-    ]
-  },
   "type": "root",
   "children": [
     {
@@ -43,5 +31,17 @@
         ]
       }
     }
-  ]
+  ],
+  "meta": {
+    "types": [
+      "has-text",
+      "has-link",
+      "nb-text-2",
+      "nb-link-1",
+      "is-text-link",
+      "is-text"
+    ]
+  },
+  "title": "This is a paragraph with a link!",
+  "intro": "This is a paragraph with a link!"
 }

--- a/src/context.d.ts
+++ b/src/context.d.ts
@@ -168,10 +168,6 @@ export interface MDAST {
       }
     | {
         /**
-         * The inferred class names for the section
-         */
-        types?: string[];
-        /**
          * The MDAST node type. Each section can be treated as a standalone document.
          */
         type?: {
@@ -182,10 +178,9 @@ export interface MDAST {
          * The AST nodes making up the section. Section dividers are not included.
          */
         children?: MDAST[];
-        /**
-         * When set to `true`, will output the additional meta properties as data attributes (i.e. `'foo = bar'` will become `data-hlx-foo='bar'`)
-         */
-        meta?: boolean;
+        meta?: null | {
+          [k: string]: any;
+        };
         /**
          * Extracted title of the document
          */

--- a/src/context.d.ts
+++ b/src/context.d.ts
@@ -11,65 +11,6 @@
  */
 
 /**
- * A section in a markdown document
- */
-export type Section = {
-  /**
-   * The inferred class names for the section
-   */
-  types?: string[];
-  /**
-   * The MDAST node type. Each section can be treated as a standalone document.
-   */
-  type?: {
-    [k: string]: any;
-  };
-  position?: Position;
-  /**
-   * The AST nodes making up the section. Section dividers are not included.
-   */
-  children?: MDAST[];
-  /**
-   * Extracted metadata from the frontmatter of the document
-   */
-  meta?: {
-    [k: string]: any;
-  };
-  /**
-   * Extracted title of the document
-   */
-  title?: string;
-  /**
-   * Extracted first paragraph of the document
-   */
-  intro?: string;
-  /**
-   * Path (can be relative) to the first image in the document
-   */
-  image?: string;
-} & {
-  /**
-   * Extracted metadata from the frontmatter of the document
-   */
-  meta?: {
-    [k: string]: any;
-  };
-  /**
-   * Extracted title of the document
-   */
-  title?: string;
-  /**
-   * Extracted first paragraph of the document
-   */
-  intro?: string;
-  /**
-   * Path (can be relative) to the first image in the document
-   */
-  image?: string;
-  [k: string]: any;
-};
-
-/**
  * The context thingie.
  */
 export interface Context {
@@ -145,10 +86,6 @@ export interface Content {
   body?: string;
   mdast?: MDAST;
   /**
-   * The extracted sections of the document
-   */
-  sections?: Section[];
-  /**
    * The DOM-compatible representation of the document's inner HTML
    */
   document?: {
@@ -166,10 +103,7 @@ export interface Content {
   xml?: {
     [k: string]: any;
   };
-  /**
-   * Extracted metadata from the frontmatter of the document
-   */
-  meta?: {
+  meta?: null | {
     [k: string]: any;
   };
   /**
@@ -226,10 +160,45 @@ export interface MDAST {
     | "imageReference"
     | "footnote"
     | "footnoteReference"
-    | "embed";
-  children?: {
-    [k: string]: any;
-  }[];
+    | "embed"
+    | "section";
+  children?: (
+    | {
+        [k: string]: any;
+      }
+    | {
+        /**
+         * The inferred class names for the section
+         */
+        types?: string[];
+        /**
+         * The MDAST node type. Each section can be treated as a standalone document.
+         */
+        type?: {
+          [k: string]: any;
+        };
+        position?: Position;
+        /**
+         * The AST nodes making up the section. Section dividers are not included.
+         */
+        children?: MDAST[];
+        /**
+         * When set to `true`, will output the additional meta properties as data attributes (i.e. `'foo = bar'` will become `data-hlx-foo='bar'`)
+         */
+        meta?: boolean;
+        /**
+         * Extracted title of the document
+         */
+        title?: string;
+        /**
+         * Extracted first paragraph of the document
+         */
+        intro?: string;
+        /**
+         * Path (can be relative) to the first image in the document
+         */
+        image?: string;
+      })[];
   position?: Position;
   /**
    * The string value of the node, if it is a terminal node.
@@ -270,10 +239,6 @@ export interface MDAST {
    */
   lang?: null | string;
   /**
-   * For code, if lang is present, a meta field can be present. It represents custom information relating to the node.
-   */
-  meta?: null | string;
-  /**
    * For associations, an identifier field must be present. It can match an identifier field on another node.
    */
   identifier?: string;
@@ -285,10 +250,25 @@ export interface MDAST {
    * For resources, an url field must be present. It represents a URL to the referenced resource.
    */
   url?: string;
+  meta?: null | {
+    [k: string]: any;
+  };
   /**
-   * For resources, a title field can be present. It represents advisory information for the resource, such as would be appropriate for a tooltip.
+   * Extracted title of the document
    */
-  title?: string | null;
+  title?: null | string;
+  /**
+   * Extracted first paragraph of the document
+   */
+  intro?: null | string;
+  /**
+   * Path (can be relative) to the first image in the document
+   */
+  image?: null | string;
+  /**
+   * The inferred class names for the section
+   */
+  types?: string[];
   /**
    * An alt field should be present. It represents equivalent content for environments that cannot represent the node as intended.
    */

--- a/src/defaults/html.pipe.js
+++ b/src/defaults/html.pipe.js
@@ -37,6 +37,7 @@ const tohtml = require('../html/stringify-response');
 const addHeaders = require('../html/add-headers');
 const timing = require('../utils/timing');
 const sanitize = require('../html/sanitize');
+const removeHlxProps = require('../html/removeHlxProps');
 const resolveRef = require('../utils/resolve-ref');
 
 /* eslint newline-per-chained-call: off */
@@ -76,6 +77,7 @@ const htmlpipe = (cont, context, action) => {
     .after(cache).when(uncached)
     .after(key)
     .after(tovdom).expose('post') // start HTML post-processing
+    .after(removeHlxProps).when(() => production())
     .after(rewriteLinks).when(production)
     .after(addHeaders)
     .after(tohtml) // end HTML post-processing

--- a/src/html/get-metadata.js
+++ b/src/html/get-metadata.js
@@ -19,10 +19,7 @@ const {
 
 function yaml(section) {
   const yamls = selectAll('yaml', section);
-  section.meta = Object.assign(
-    { type: section.type },
-    obj(flat(map(yamls, ({ payload }) => payload))),
-  );
+  section.meta = Object.assign({}, obj(flat(map(yamls, ({ payload }) => payload))));
   return section;
 }
 

--- a/src/html/get-metadata.js
+++ b/src/html/get-metadata.js
@@ -19,7 +19,7 @@ const {
 
 function yaml(section) {
   const yamls = selectAll('yaml', section);
-  section.meta = Object.assign({}, obj(flat(map(yamls, ({ payload }) => payload))));
+  section.meta = obj(flat(map(yamls, ({ payload }) => payload)));
   return section;
 }
 
@@ -145,7 +145,7 @@ function fallback(section) {
 
 function getmetadata({ content }, { logger }) {
   const { mdast: { children } } = content;
-  const sections = children.filter(node => node.type === 'root');
+  const sections = children.filter(node => node.type === 'section');
   if (!sections) {
     content.meta = {};
     return;

--- a/src/html/get-metadata.js
+++ b/src/html/get-metadata.js
@@ -30,7 +30,7 @@ function title(section) {
 
 function intro(section) {
   const para = selectAll('paragraph', section).filter((p) => {
-    if ((p.children.length === 0)
+    if ((!p.children || p.children.length === 0)
         || (p.children.length === 1 && p.children[0].type === 'image')) {
       return false;
     }
@@ -144,11 +144,10 @@ function fallback(section) {
 }
 
 function getmetadata({ content }, { logger }) {
-  const { mdast: { children } } = content;
-  const sections = children.filter(node => node.type === 'section');
-  if (!sections) {
-    content.meta = {};
-    return;
+  const { mdast: { children = [] } } = content;
+  let sections = children.filter(node => node.type === 'section');
+  if (!sections.length) {
+    sections = [content.mdast];
   }
 
   logger.debug(`Parsing Markdown Metadata from ${sections.length} sections`);

--- a/src/html/get-metadata.js
+++ b/src/html/get-metadata.js
@@ -19,14 +19,16 @@ const {
 
 function yaml(section) {
   const yamls = selectAll('yaml', section);
-  section.data = section.data || {};
-  section.data.meta = obj(flat(map(yamls, ({ payload }) => payload)));
+  section.meta = Object.assign(
+    { type: section.type },
+    obj(flat(map(yamls, ({ payload }) => payload))),
+  );
   return section;
 }
 
 function title(section) {
   const header = select('heading', section);
-  section.data.title = header ? plain(header) : '';
+  section.title = header ? plain(header) : '';
 }
 
 function intro(section) {
@@ -37,7 +39,7 @@ function intro(section) {
     }
     return true;
   })[0];
-  section.data.intro = para ? plain(para) : '';
+  section.intro = para ? plain(para) : '';
 }
 
 function image(section) {
@@ -45,7 +47,7 @@ function image(section) {
   // TODO: get a better measure of prominence than "first"
   const img = select('image', section);
   if (img) {
-    section.data.image = img.url;
+    section.image = img.url;
   }
 }
 
@@ -133,35 +135,36 @@ function sectiontype(section) {
   }
 
   const typecounter = children.reduce(reducer, {});
-  section.data.types = constructTypes(typecounter);
+  section.types = constructTypes(typecounter);
 }
 
 function fallback(section) {
   if (section.intro && !section.title) {
-    section.data.title = section.intro;
+    section.title = section.intro;
   } else if (section.title && !section.intro) {
-    section.data.intro = section.title;
+    section.intro = section.title;
   }
 }
 
 function getmetadata({ content }, { logger }) {
   const { mdast: { children } } = content;
-  if (!children) {
+  const sections = children.filter(node => node.type === 'root');
+  if (!sections) {
     content.meta = {};
     return;
   }
 
-  logger.debug(`Parsing Markdown Metadata from ${children.length} sections`);
+  logger.debug(`Parsing Markdown Metadata from ${sections.length} sections`);
 
   each([yaml, title, intro, image, sectiontype, fallback], (fn) => {
-    each(children, fn);
+    each(sections, fn);
   });
 
-  const img = children.filter(section => section.image)[0];
+  const img = sections.filter(section => section.image)[0];
 
-  content.meta = empty(children) ? {} : children[0].meta;
-  content.title = empty(children) ? '' : children[0].title;
-  content.intro = empty(children) ? '' : children[0].intro;
+  content.meta = empty(sections) ? {} : sections[0].meta;
+  content.title = empty(sections) ? '' : sections[0].title;
+  content.intro = empty(sections) ? '' : sections[0].intro;
   content.image = img ? img.image : undefined;
 }
 

--- a/src/html/get-metadata.js
+++ b/src/html/get-metadata.js
@@ -19,13 +19,14 @@ const {
 
 function yaml(section) {
   const yamls = selectAll('yaml', section);
-  section.meta = obj(flat(map(yamls, ({ payload }) => payload)));
+  section.data = section.data || {};
+  section.data.meta = obj(flat(map(yamls, ({ payload }) => payload)));
   return section;
 }
 
 function title(section) {
   const header = select('heading', section);
-  section.title = header ? plain(header) : '';
+  section.data.title = header ? plain(header) : '';
 }
 
 function intro(section) {
@@ -36,7 +37,7 @@ function intro(section) {
     }
     return true;
   })[0];
-  section.intro = para ? plain(para) : '';
+  section.data.intro = para ? plain(para) : '';
 }
 
 function image(section) {
@@ -44,7 +45,7 @@ function image(section) {
   // TODO: get a better measure of prominence than "first"
   const img = select('image', section);
   if (img) {
-    section.image = img.url;
+    section.data.image = img.url;
   }
 }
 
@@ -132,35 +133,35 @@ function sectiontype(section) {
   }
 
   const typecounter = children.reduce(reducer, {});
-  section.types = constructTypes(typecounter);
+  section.data.types = constructTypes(typecounter);
 }
 
 function fallback(section) {
   if (section.intro && !section.title) {
-    section.title = section.intro;
+    section.data.title = section.intro;
   } else if (section.title && !section.intro) {
-    section.intro = section.title;
+    section.data.intro = section.title;
   }
 }
 
 function getmetadata({ content }, { logger }) {
-  const { sections } = content;
-  if (!sections) {
+  const { mdast: { children } } = content;
+  if (!children) {
     content.meta = {};
     return;
   }
 
-  logger.debug(`Parsing Markdown Metadata from ${sections.length} sections`);
+  logger.debug(`Parsing Markdown Metadata from ${children.length} sections`);
 
   each([yaml, title, intro, image, sectiontype, fallback], (fn) => {
-    each(sections, fn);
+    each(children, fn);
   });
 
-  const img = sections.filter(section => section.image)[0];
+  const img = children.filter(section => section.image)[0];
 
-  content.meta = empty(sections) ? {} : sections[0].meta;
-  content.title = empty(sections) ? '' : sections[0].title;
-  content.intro = empty(sections) ? '' : sections[0].intro;
+  content.meta = empty(children) ? {} : children[0].meta;
+  content.title = empty(children) ? '' : children[0].title;
+  content.intro = empty(children) ? '' : children[0].intro;
   content.image = img ? img.image : undefined;
 }
 

--- a/src/html/get-metadata.js
+++ b/src/html/get-metadata.js
@@ -11,7 +11,6 @@
  */
 const { select, selectAll } = require('unist-util-select');
 const plain = require('mdast-util-to-string');
-const { empty } = require('@adobe/helix-shared').types;
 const {
   flat, obj, map, each,
 } = require('@adobe/helix-shared').sequence;
@@ -158,9 +157,9 @@ function getmetadata({ content }, { logger }) {
 
   const img = sections.filter(section => section.image)[0];
 
-  content.meta = empty(sections) ? {} : sections[0].meta;
-  content.title = empty(sections) ? '' : sections[0].title;
-  content.intro = empty(sections) ? '' : sections[0].intro;
+  content.meta = sections[0].meta;
+  content.title = sections[0].title;
+  content.intro = sections[0].intro;
   content.image = img ? img.image : undefined;
 }
 

--- a/src/html/get-metadata.js
+++ b/src/html/get-metadata.js
@@ -80,7 +80,7 @@ function sectiontype(section) {
   function reducer(counter, node) {
     const { type, children: pChildren } = node;
 
-    node.data = Object.assign({ types: [] }, node.data);
+    node.meta = Object.assign({ types: [] }, node.meta);
 
     if (type === 'yaml') {
       return counter;
@@ -100,8 +100,8 @@ function sectiontype(section) {
           // paragraph with type text "is" a text
           prefix = 'is';
         }
-        if (!node.data.types.includes(`${prefix}-${p.type}`)) {
-          node.data.types.push(`${prefix}-${p.type}`);
+        if (!node.meta.types.includes(`${prefix}-${p.type}`)) {
+          node.meta.types.push(`${prefix}-${p.type}`);
         }
         const mycount = mycounter[p.type] || 0;
         mycounter[p.type] = mycount + 1;
@@ -114,14 +114,14 @@ function sectiontype(section) {
       pChildren.forEach((listitem) => {
         listtypecounter = listitem.children.reduce(reducer, listtypecounter);
       });
-      constructTypes(listtypecounter).forEach(item => node.data.types.push(item));
+      constructTypes(listtypecounter).forEach(item => node.meta.types.push(item));
     }
 
     if (Object.keys(mycounter).length === 0) {
       // was really a paragraph, only text inside
       const mycount = mycounter[type] || 0;
       mycounter[type] = mycount + 1;
-      node.data.types.push(`is-${type}`);
+      node.meta.types.push(`is-${type}`);
     }
 
     Object.keys(counter).forEach((key) => {
@@ -131,7 +131,7 @@ function sectiontype(section) {
   }
 
   const typecounter = children.reduce(reducer, {});
-  section.types = constructTypes(typecounter);
+  section.meta.types = constructTypes(typecounter);
 }
 
 function fallback(section) {

--- a/src/html/removeHlxProps.js
+++ b/src/html/removeHlxProps.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+function clean({ response }) {
+  response.document.querySelectorAll('[class]').forEach((el) => {
+    // Remove all `hlx-*` classes on the elements
+    el.classList.value.split(' ')
+      .filter(cls => cls.indexOf('hlx-') === 0)
+      .forEach(cls => el.classList.remove(cls));
+    if (!el.classList.length) {
+      el.removeAttribute('class');
+    }
+
+    // Remove all `data-hlx-*` attributes on these elements
+    Object.keys(el.dataset)
+      .filter(key => key.match(/^hlx[A-Z]/))
+      .forEach(key => delete el.dataset[key]);
+  });
+}
+
+module.exports = clean;

--- a/src/html/split-sections.js
+++ b/src/html/split-sections.js
@@ -17,7 +17,7 @@ const _ = require('lodash/fp');
 
 // Compute the meta information for the section
 function computeMeta(section) {
-  return Object.assign({}, obj(flat(map(selectAll('yaml', section), ({ payload }) => payload))));
+  return obj(flat(map(selectAll('yaml', section), ({ payload }) => payload)));
 }
 
 function split({ content }) {
@@ -48,7 +48,8 @@ function split({ content }) {
       return section;
     });
 
-  if (content.mdast.children.length === 1 && content.mdast.children[0].type === 'section') { // unwrap sole section
+  // unwrap sole section directly on the root
+  if (content.mdast.children.length === 1 && content.mdast.children[0].type === 'section') {
     content.mdast.children = content.mdast.children[0].children;
   }
 }

--- a/src/html/split-sections.js
+++ b/src/html/split-sections.js
@@ -12,7 +12,7 @@
 
 const between = require('unist-util-find-all-between');
 const { selectAll } = require('unist-util-select');
-const { flat, obj, map } = require('@adobe/helix-shared').sequence;
+const { flat, obj, map } = require('ferrum');
 const _ = require('lodash/fp');
 
 // Compute the meta information for the section

--- a/src/html/split-sections.js
+++ b/src/html/split-sections.js
@@ -17,7 +17,7 @@ const _ = require('lodash/fp');
 
 // Compute the meta information for the section
 function computeMeta(section) {
-  return obj(flat(map(selectAll('yaml', section), ({ payload }) => payload)));
+  return Object.assign({}, obj(flat(map(selectAll('yaml', section), ({ payload }) => payload))));
 }
 
 function split({ content }) {
@@ -41,15 +41,14 @@ function split({ content }) {
     // skip 'thematicBreak' nodes
       const index = mdast.children[start].type === 'thematicBreak' ? start + 1 : start;
       const section = {
-        type: 'root',
-        data: {},
+        type: 'section',
         children: between(mdast, index, end),
       };
-      section.data.meta = computeMeta(section);
+      section.meta = computeMeta(section);
       return section;
     });
 
-  if (content.mdast.children.length === 1) { // unwrap sole section
+  if (content.mdast.children.length === 1 && content.mdast.children[0].type === 'section') { // unwrap sole section
     content.mdast.children = content.mdast.children[0].children;
   }
 }

--- a/src/html/unwrap-sole-images.js
+++ b/src/html/unwrap-sole-images.js
@@ -25,8 +25,8 @@ function unwrap({ content }) {
     map(section, (node, index, parent) => {
       if (node.type === 'paragraph' // If we have a paragraph
           && parent.type === 'root' // … in a top section
-          && parent.types.includes('has-only-image') // … that only has images
-          && parent.types.includes('nb-image-1')) { // … and actually only 1 of them
+          && parent.meta.types.includes('has-only-image') // … that only has images
+          && parent.meta.types.includes('nb-image-1')) { // … and actually only 1 of them
         // … then consider it a hero image, and unwrap from the paragraph
         const position = content.mdast.children.indexOf(node);
         const [img] = content.mdast.children[position].children;

--- a/src/html/unwrap-sole-images.js
+++ b/src/html/unwrap-sole-images.js
@@ -17,7 +17,11 @@ const map = require('unist-util-map');
  * @param {object} request The content request
  */
 function unwrap({ content }) {
-  content.sections.forEach((section) => {
+  let sections = content.mdast.children.filter(node => node.type === 'section');
+  if (!sections.length) {
+    sections = [content.mdast];
+  }
+  sections.forEach((section) => {
     map(section, (node, index, parent) => {
       if (node.type === 'paragraph' // If we have a paragraph
           && parent.type === 'root' // … in a top section

--- a/src/schemas/content.schema.json
+++ b/src/schemas/content.schema.json
@@ -33,13 +33,6 @@
     "mdast": {
       "$ref": "https://ns.adobe.com/helix/pipeline/mdast"
     },
-    "sections": {
-      "type": "array",
-      "description": "The extracted sections of the document",
-      "items": {
-        "$ref": "https://ns.adobe.com/helix/pipeline/section"
-      }
-    },
     "document": {
       "type": "object",
       "description": "The DOM-compatible representation of the document's inner HTML"

--- a/src/schemas/content.schema.json
+++ b/src/schemas/content.schema.json
@@ -46,7 +46,7 @@
       "description": "The XML object to emit. See xmlbuilder-js for syntax."
     },
     "meta": {
-      "$ref": "https://ns.adobe.com/helix/pipeline/meta#/definitions/meta/properties/meta"
+      "$ref": "https://ns.adobe.com/helix/pipeline/meta#/definitions/meta"
     },
     "title": {
       "$ref": "https://ns.adobe.com/helix/pipeline/meta#/definitions/meta/properties/title"

--- a/src/schemas/mdast.schema.json
+++ b/src/schemas/mdast.schema.json
@@ -78,7 +78,7 @@
         "footnote": "A footnote",
         "footnoteReference": "A reference to a footnote",
         "embed": "Content embedded from another page, identified by the `url` attribute.",
-        "section": "The extracted sections of the document"
+        "section": "A section within the document. Sections serve as a high-level structure of a single markdown document and can have their own section-specific front matter metadata."
       },
       "description": "The node type of the MDAST node"
     },

--- a/src/schemas/mdast.schema.json
+++ b/src/schemas/mdast.schema.json
@@ -47,7 +47,8 @@
         "imageReference",
         "footnote",
         "footnoteReference",
-        "embed"
+        "embed",
+        "section"
       ],
       "meta:enum": {
         "root": "The root node, representing a document or section",
@@ -76,15 +77,21 @@
         "imageReference": "A pointer to an image",
         "footnote": "A footnote",
         "footnoteReference": "A reference to a footnote",
-        "embed": "Content embedded from another page, identified by the `url` attribute."
+        "embed": "Content embedded from another page, identified by the `url` attribute.",
+        "section": "The extracted sections of the document"
       },
       "description": "The node type of the MDAST node"
     },
     "children": {
       "type": "array",
-      "items": {
-        "$ref": "https://ns.adobe.com/helix/pipeline/mdast"
-      }
+      "oneOf": [
+        {
+            "$ref": "https://ns.adobe.com/helix/pipeline/mdast"
+        },
+        {
+            "$ref": "https://ns.adobe.com/helix/pipeline/section#/definitions/section"
+        }
+      ]
     },
     "position": {
       "$ref": "https://ns.adobe.com/helix/pipeline/position"

--- a/src/schemas/mdast.schema.json
+++ b/src/schemas/mdast.schema.json
@@ -84,14 +84,16 @@
     },
     "children": {
       "type": "array",
-      "oneOf": [
-        {
-            "$ref": "https://ns.adobe.com/helix/pipeline/mdast"
-        },
-        {
-            "$ref": "https://ns.adobe.com/helix/pipeline/section#/definitions/section"
-        }
-      ]
+      "items": {
+        "oneOf": [
+          {
+              "$ref": "https://ns.adobe.com/helix/pipeline/mdast"
+          },
+          {
+              "$ref": "https://ns.adobe.com/helix/pipeline/section#/definitions/section"
+          }
+        ]
+      }
     },
     "position": {
       "$ref": "https://ns.adobe.com/helix/pipeline/position"
@@ -138,10 +140,6 @@
       "type": ["null", "string"],
       "description": "For code, a lang field can be present. It represents the language of computer code being marked up."
     },
-    "meta": {
-      "type": ["null", "string"],
-      "description": "For code, if lang is present, a meta field can be present. It represents custom information relating to the node."
-    },
     "identifier": {
       "type": "string",
       "description": "For associations, an identifier field must be present. It can match an identifier field on another node."
@@ -155,9 +153,29 @@
       "format": "uri-reference",
       "description": "For resources, an url field must be present. It represents a URL to the referenced resource."
     },
+    "meta": {
+      "type": ["null", "object"],
+      "description": "Extracted metadata from the frontmatter of the document"
+    },
     "title": {
-      "type": ["string", "null"],
-      "description": "For resources, a title field can be present. It represents advisory information for the resource, such as would be appropriate for a tooltip."
+      "type": ["null", "string"],
+      "description": "Extracted title of the document"
+    },
+    "intro": {
+      "type": ["null", "string"],
+      "description": "Extracted first paragraph of the document"
+    },
+    "image": {
+      "type": ["null", "string"],
+      "format": "uri-reference",
+      "description": "Path (can be relative) to the first image in the document"
+    },
+    "types": {
+      "type": "array",
+      "description": "The inferred class names for the section",
+      "items": {
+        "type": "string"
+      }
     },
     "alt": {
       "type": ["string", "null"],

--- a/src/schemas/mdast.schema.json
+++ b/src/schemas/mdast.schema.json
@@ -154,8 +154,7 @@
       "description": "For resources, an url field must be present. It represents a URL to the referenced resource."
     },
     "meta": {
-      "type": ["null", "object"],
-      "description": "Extracted metadata from the frontmatter of the document"
+      "$ref": "https://ns.adobe.com/helix/pipeline/meta#/definitions/meta"
     },
     "title": {
       "type": ["null", "string"],

--- a/src/schemas/meta.schema.json
+++ b/src/schemas/meta.schema.json
@@ -17,10 +17,23 @@
   "description": "Content and Section Metadata Properties",
   "definitions": {
     "meta": {
+      "type": ["null", "object"],
       "properties": {
+        "class": {
+          "type": "string",
+          "description": "The CSS class to use for the section instead of the default `hlx-section` one"
+        },
+        "tagname": {
+          "type": "string",
+          "description": "The element tag name to use for the section instead of the default `div` one (i.e. `section`, `main`, `aside`)"
+        },
         "meta": {
-          "type": "object",
-          "description": "Extracted metadata from the frontmatter of the document"
+          "type": "boolean",
+          "description": "When set to `true`, will output the additional meta properties as data attributes (i.e. `'foo = bar'` will become `data-hlx-foo='bar'`)"
+        },
+        "types": {
+          "type": "boolean",
+          "description": "When set to `true`, will output the section types as additional CSS classes (i.e. `class='hlx-section has-image has-heading'`)"
         },
         "title": {
           "type": "string",

--- a/src/schemas/meta.schema.json
+++ b/src/schemas/meta.schema.json
@@ -27,13 +27,12 @@
           "type": "string",
           "description": "The element tag name to use for the section instead of the default `div` one (i.e. `section`, `main`, `aside`)"
         },
-        "meta": {
-          "type": "boolean",
-          "description": "When set to `true`, will output the additional meta properties as data attributes (i.e. `'foo = bar'` will become `data-hlx-foo='bar'`)"
-        },
         "types": {
-          "type": "boolean",
-          "description": "When set to `true`, will output the section types as additional CSS classes (i.e. `class='hlx-section has-image has-heading'`)"
+          "type": "array",
+          "description": "The inferred class names for the section",
+          "items": {
+            "type": "string"
+          }
         },
         "title": {
           "type": "string",

--- a/src/schemas/section.schema.json
+++ b/src/schemas/section.schema.json
@@ -19,13 +19,6 @@
     "section": {
       "additionalProperties": false,
       "properties": {
-        "types": {
-          "type": "array",
-          "description": "The inferred class names for the section",
-          "items": {
-            "type": "string"
-          }
-        },
         "type": {
           "const": "root",
           "description": "The MDAST node type. Each section can be treated as a standalone document."
@@ -41,7 +34,7 @@
           }
         },
         "meta": {
-          "$ref": "https://ns.adobe.com/helix/pipeline/meta#/definitions/meta/properties/meta"
+          "$ref": "https://ns.adobe.com/helix/pipeline/meta#/definitions/meta"
         },
         "title": {
           "$ref": "https://ns.adobe.com/helix/pipeline/meta#/definitions/meta/properties/title"

--- a/src/schemas/section.schema.json
+++ b/src/schemas/section.schema.json
@@ -54,9 +54,5 @@
         }
       }
     }
-  },
-  "allOf": [
-    {"$ref": "#/definitions/section"},
-    {"$ref": "https://ns.adobe.com/helix/pipeline/meta#/definitions/meta"}
-  ]
+  }
 }

--- a/src/utils/conditional-sections.js
+++ b/src/utils/conditional-sections.js
@@ -15,10 +15,10 @@ const { setdefault, type } = require('@adobe/helix-shared').types;
 const { each } = require('@adobe/helix-shared').sequence;
 
 function selectstrain(context, { request, logger }) {
-  const cont = setdefault(context, 'content', {});
+  const cont = setdefault(context, 'content', { mdast: {} });
   const params = request.params || {};
   const { strain } = params;
-  const { sections } = cont;
+  const sections = cont.mdast.children;
 
   if (!strain || !sections) {
     return;
@@ -70,10 +70,10 @@ function pick(groups = {}, strain = 'default') {
 }
 
 function selecttest(context, { request }) {
-  const cont = setdefault(context, 'content', {});
+  const cont = setdefault(context, 'content', { mdast: {} });
   const params = request.params || {};
   const { strain } = params;
-  const { sections } = cont;
+  const sections = cont.mdast.children;
 
   if (!strain || !sections) {
     return;

--- a/src/utils/mdast-to-vdom.js
+++ b/src/utils/mdast-to-vdom.js
@@ -57,7 +57,7 @@ class VDOMTransformer {
     this.match('heading', this._headingHandler.handler());
     this.match('embed', embed(options));
     this.match('link', link(options));
-    this.match('root', section(options));
+    this.match('section', section(options));
     this.match('html', (h, node) => {
       if (node.value.startsWith('<!--')) {
         return h.augment(node, {

--- a/src/utils/mdast-to-vdom.js
+++ b/src/utils/mdast-to-vdom.js
@@ -19,6 +19,7 @@ const toDOM = require('./hast-util-to-dom');
 const HeadingHandler = require('./heading-handler');
 const embed = require('./embed-handler');
 const link = require('./link-handler');
+const section = require('./section-handler');
 const types = require('../schemas/mdast.schema.json').properties.type.enum;
 
 /**
@@ -56,6 +57,7 @@ class VDOMTransformer {
     this.match('heading', this._headingHandler.handler());
     this.match('embed', embed(options));
     this.match('link', link(options));
+    this.match('root', section(options));
     this.match('html', (h, node) => {
       if (node.value.startsWith('<!--')) {
         return h.augment(node, {

--- a/src/utils/section-handler.js
+++ b/src/utils/section-handler.js
@@ -9,13 +9,11 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
-const fallback = require('mdast-util-to-hast/lib/handlers/root');
 const all = require('mdast-util-to-hast/lib/all');
 const wrap = require('mdast-util-to-hast/lib/wrap');
 
 const DEFAULT_SECTION_TAG = 'div';
-const DEFAULT_SECTION_CLASS = 'hlx-Section';
+const DEFAULT_SECTION_CLASS = 'hlx-section';
 const SYSTEM_META_PROPERTIES = ['class', 'meta', 'tagname', 'types'];
 
 /**
@@ -41,18 +39,6 @@ function getTypes(node) {
 }
 
 /**
- * Formats the `type` attribute of the section, using following patterns:
- * 1. has-<type> becomes `has<Type>`
- * 2. is-<type>-only becomes `is<Type>Only`
- * 3. is-<type1>-<type2>-<type3> becomes `is<Type1><Type2><Type3>`
- * 4. nb-<type>-<nb_occurences> becomes `nb<Type><Nb_Occurences>`
- * @param {*} section
- */
-function formatType(type) {
-  return type.replace(/-([\w])/g, g => g[1].toUpperCase());
-}
-
-/**
  * Get the class name for the specified section.
  *
  * @param {Node} section The MDAST section to get the class name for
@@ -61,9 +47,8 @@ function formatType(type) {
  */
 function getClass(section) {
   const sectionClass = (section.meta && section.meta.class) || DEFAULT_SECTION_CLASS;
-  const sectionTypes = getTypes(section).map(type => formatType(type));
-  const sectionTypesClasses = sectionTypes.map(type => `${sectionClass}--${type}`);
-  return [].concat(sectionClass, sectionTypesClasses).join(' ');
+  const sectionTypes = getTypes(section);
+  return [sectionClass, ...sectionTypes].join(' ');
 }
 
 /**
@@ -85,18 +70,13 @@ function getMeta(section) {
 }
 
 function sectionHandler() {
-  return function handler(h, node, parent) {
+  return function handler(h, node) {
     const n = Object.assign({}, node);
 
-    // we have a section that is not the document root, so wrap it in the desired tag
-    if (parent && parent.type === 'root' && parent.children.length > 1) {
-      const tagName = getTagName(n);
-      const props = Object.assign({ class: getClass(n) }, getMeta(n));
-      const children = wrap(all(h, n), true);
-      return h(node, tagName, props, children);
-    }
-
-    return fallback(h, n);
+    const tagName = getTagName(n);
+    const props = Object.assign({ class: getClass(n) }, getMeta(n));
+    const children = wrap(all(h, n), true);
+    return h(node, tagName, props, children);
   };
 }
 

--- a/src/utils/section-handler.js
+++ b/src/utils/section-handler.js
@@ -13,7 +13,8 @@ const all = require('mdast-util-to-hast/lib/all');
 const wrap = require('mdast-util-to-hast/lib/wrap');
 
 const DEFAULT_SECTION_TAG = 'div';
-const DEFAULT_SECTION_CLASS = 'hlx-section';
+const HELIX_NAMESPACE = 'hlx';
+const DEFAULT_SECTION_CLASS = `${HELIX_NAMESPACE}-section`;
 const SYSTEM_META_PROPERTIES = ['class', 'meta', 'tagname', 'types'];
 
 /**
@@ -64,7 +65,7 @@ function getMeta(section) {
       .filter(prop => SYSTEM_META_PROPERTIES.indexOf(prop) === -1);
   }
   return metaKeys.reduce((props, key) => {
-    props[`data-hlx-${key}`] = section.meta[key];
+    props[`data-${HELIX_NAMESPACE}-${key}`] = section.meta[key];
     return props;
   }, {});
 }
@@ -76,6 +77,7 @@ function sectionHandler() {
     const tagName = getTagName(n);
     const props = Object.assign({ class: getClass(n) }, getMeta(n));
     const children = wrap(all(h, n), true);
+
     return h(node, tagName, props, children);
   };
 }

--- a/src/utils/section-handler.js
+++ b/src/utils/section-handler.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const fallback = require('mdast-util-to-hast/lib/handlers/root');
+const all = require('mdast-util-to-hast/lib/all');
+const wrap = require('mdast-util-to-hast/lib/wrap');
+
+/**
+ * Get the tag name for the specified section.
+ *
+ * @param {Node} section The MDAST section to get the tag name for
+ * @returns {string} The tag name for the section. Defaults to {@code div}.
+ */
+function getTageName(section) {
+  return (section.data && section.data.meta && section.data.meta.tagName) || 'div';
+}
+
+/**
+ * Get the class name for the specified section.
+ *
+ * @param {Node} section The MDAST section to get the class name for
+ * @returns {string} The class name for the section. Defaults to {@code hlx-section}.
+ */
+function getClass(section) {
+  return (section.data && section.data.meta && section.data.meta.className) || 'hlx-section';
+}
+
+/**
+ * Get the types for the specified section.
+ *
+ * @param {Node} section The MDAST section to get the types for
+ * @returns {string} A space-separated list of section types, or {@code null} if none desired.
+ */
+function getTypes(node) {
+  const outputTags = node.data && node.data.meta && node.data.meta.types === true;
+  const types = (outputTags && node.data.types) || null;
+  return types ? types.join(' ') : null;
+}
+
+function sectionHandler() {
+  return function handler(h, node, parent) {
+    const n = Object.assign({}, node);
+
+    // we have a section that is not the document root, so wrap it in the desired tag
+    if (parent && parent.type === 'root') {
+      const tagName = getTageName(n);
+      const props = { class: getClass(n), 'data-hlx-types': getTypes(n) };
+      const children = wrap(all(h, n), true);
+      return h(node, tagName, props, children);
+    }
+
+    return fallback(h, n);
+  };
+}
+
+module.exports = sectionHandler;

--- a/src/utils/section-handler.js
+++ b/src/utils/section-handler.js
@@ -21,7 +21,7 @@ const wrap = require('mdast-util-to-hast/lib/wrap');
  * @returns {string} The tag name for the section. Defaults to {@code div}.
  */
 function getTageName(section) {
-  return (section.data && section.data.meta && section.data.meta.tagName) || 'div';
+  return (section.meta && section.meta.tagName) || 'div';
 }
 
 /**
@@ -31,7 +31,7 @@ function getTageName(section) {
  * @returns {string} The class name for the section. Defaults to {@code hlx-section}.
  */
 function getClass(section) {
-  return (section.data && section.data.meta && section.data.meta.className) || 'hlx-section';
+  return (section.meta && section.meta.className) || 'hlx-section';
 }
 
 /**
@@ -41,8 +41,8 @@ function getClass(section) {
  * @returns {string} A space-separated list of section types, or {@code null} if none desired.
  */
 function getTypes(node) {
-  const outputTags = node.data && node.data.meta && node.data.meta.types === true;
-  const types = (outputTags && node.data.types) || null;
+  const outputTags = node.meta && node.meta.types === true;
+  const types = (outputTags && node.types) || null;
   return types ? types.join(' ') : null;
 }
 
@@ -51,7 +51,7 @@ function sectionHandler() {
     const n = Object.assign({}, node);
 
     // we have a section that is not the document root, so wrap it in the desired tag
-    if (parent && parent.type === 'root') {
+    if (parent && parent.type === 'root' && parent.children.length > 1) {
       const tagName = getTageName(n);
       const props = { class: getClass(n), 'data-hlx-types': getTypes(n) };
       const children = wrap(all(h, n), true);

--- a/test/fixtures/sections.json
+++ b/test/fixtures/sections.json
@@ -2,12 +2,14 @@
   {
     "type": "section",
     "meta": {
-      "title": "foo"
+      "title": "foo",
+      "types": true
     },
     "children": [{
         "type": "yaml",
         "payload": {
-          "title": "foo"
+          "title": "foo",
+          "types": true
         }
       },
       {

--- a/test/fixtures/sections.json
+++ b/test/fixtures/sections.json
@@ -1,6 +1,9 @@
 [
   {
-    "type": "root",
+    "type": "section",
+    "meta": {
+      "title": "foo"
+    },
     "children": [{
         "type": "yaml",
         "payload": {
@@ -130,11 +133,16 @@
     ]
   },
   {
-    "type": "root",
+    "type": "section",
+    "meta": {
+      "class": "section",
+      "tagname": "section"
+    },
     "children": [{
         "type": "yaml",
         "payload": {
-          "class": "section"
+          "class": "section",
+          "tagname": "section"
         }
       },
       {
@@ -305,11 +313,18 @@
     ]
   },
   {
-    "type": "root",
+    "type": "section",
+    "meta": {
+      "class": "code",
+      "meta": true,
+      "bar": "baz"
+    },
     "children": [{
         "type": "yaml",
         "payload": {
-          "class": "code"
+          "class": "code",
+          "meta": true,
+          "bar": "baz"
         }
       },
       {
@@ -472,7 +487,8 @@
     ]
   },
   {
-    "type": "root",
+    "type": "section",
+    "meta": {},
     "children": [{
         "type": "heading",
         "depth": 3,

--- a/test/fixtures/sections.md
+++ b/test/fixtures/sections.md
@@ -18,6 +18,7 @@ It uses reducers and continuations to create a simple processing pipeline that c
 
 ---
 class: section
+tagname: section
 ---
 
 ## Anatomy of a Pipeline
@@ -41,6 +42,8 @@ Typically, there is one pipeline for each content type supported and pipeline ar
 
 ---
 class: code
+meta: true
+bar: baz
 ---
 
 

--- a/test/fixtures/sections.md
+++ b/test/fixtures/sections.md
@@ -1,5 +1,6 @@
 ---
 title: foo
+types: true
 ---
 
 # Hypermedia Pipeline

--- a/test/fixtures/sections/2images.json
+++ b/test/fixtures/sections/2images.json
@@ -1,42 +1,40 @@
-[
-  {
-    "title": "helix-logo\nhelix-logo",
-    "types": [
-      "has-image",
-      "nb-image-2",
-      "has-only-image"
-    ],
-    "image": "./helix_logo.png",
-    "intro": "helix-logo\nhelix-logo",
-    "meta": {},
-    "type": "root",
-    "children": [
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "image",
-            "title": null,
-            "url": "./helix_logo.png",
-            "alt": "helix-logo"
-          },
-          {
-            "type": "text",
-            "value": "\n"
-          },
-          {
-            "type": "image",
-            "title": null,
-            "url": "./helix_logo.png",
-            "alt": "helix-logo"
-          }
-        ],
-        "data": {
-          "types": [
-            "has-image"
-          ]
+{
+  "title": "helix-logo\nhelix-logo",
+  "types": [
+    "has-image",
+    "nb-image-2",
+    "has-only-image"
+  ],
+  "image": "./helix_logo.png",
+  "intro": "helix-logo\nhelix-logo",
+  "meta": {},
+  "type": "root",
+  "children": [
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "image",
+          "title": null,
+          "url": "./helix_logo.png",
+          "alt": "helix-logo"
+        },
+        {
+          "type": "text",
+          "value": "\n"
+        },
+        {
+          "type": "image",
+          "title": null,
+          "url": "./helix_logo.png",
+          "alt": "helix-logo"
         }
+      ],
+      "data": {
+        "types": [
+          "has-image"
+        ]
       }
-    ]
-  }
-]
+    }
+  ]
+}

--- a/test/fixtures/sections/complex.json
+++ b/test/fixtures/sections/complex.json
@@ -1,2356 +1,2359 @@
-[
-  {
-    "types": [
-      "has-link",
-      "has-text",
-      "has-heading",
-      "nb-link-6",
-      "nb-text-3",
-      "nb-heading-2",
-      "is-link-text-heading",
-      "is-link-text",
-      "is-link"
-    ],
-    "image": "https://img.shields.io/codecov/c/github/adobe/hypermedia-pipeline.svg",
-    "intro": "This project provides helper functions and default implementations for creating Hypermedia Processing Pipelines.",
-    "title": "Hypermedia Pipeline",
-    "meta": {
-      "title": "foo"
-    },
-    "type": "root",
-    "children": [
-      {
-        "type": "yaml",
-        "payload": {
-          "title": "foo"
+{
+  "type": "root",
+  "children": [
+    {
+      "types": [
+        "has-link",
+        "has-text",
+        "has-heading",
+        "nb-link-6",
+        "nb-text-3",
+        "nb-heading-2",
+        "is-link-text-heading",
+        "is-link-text",
+        "is-link"
+      ],
+      "image": "https://img.shields.io/codecov/c/github/adobe/hypermedia-pipeline.svg",
+      "intro": "This project provides helper functions and default implementations for creating Hypermedia Processing Pipelines.",
+      "title": "Hypermedia Pipeline",
+      "meta": {
+        "title": "foo"
+      },
+      "type": "section",
+      "children": [
+        {
+          "type": "yaml",
+          "payload": {
+            "title": "foo"
+          },
+          "data": {
+            "types": []
+          }
         },
-        "data": {
-          "types": []
-        }
-      },
-      {
-        "type": "heading",
-        "depth": 1,
-        "children": [
-          {
-            "type": "text",
-            "value": "Hypermedia Pipeline"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-heading"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "This project provides helper functions and default implementations for creating Hypermedia Processing Pipelines."
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "It uses reducers and continuations to create a simple processing pipeline that can pre-and post-process HTML, JSON, and other hypermedia."
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text"
-          ]
-        }
-      },
-      {
-        "type": "heading",
-        "depth": 1,
-        "children": [
-          {
-            "type": "text",
-            "value": "Status"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-heading"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "link",
-            "title": null,
-            "url": "https://codecov.io/gh/adobe/hypermedia-pipeline",
-            "children": [
-              {
-                "type": "image",
-                "title": null,
-                "url": "https://img.shields.io/codecov/c/github/adobe/hypermedia-pipeline.svg",
-                "alt": "codecov"
-              }
-            ]
-          },
-          {
-            "type": "text",
-            "value": "\n"
-          },
-          {
-            "type": "link",
-            "title": null,
-            "url": "https://circleci.com/gh/adobe/parcel-plugin-htl",
-            "children": [
-              {
-                "type": "image",
-                "title": null,
-                "url": "https://img.shields.io/circleci/project/github/adobe/hypermedia-pipeline.svg",
-                "alt": "CircleCI"
-              }
-            ]
-          },
-          {
-            "type": "text",
-            "value": "\n"
-          },
-          {
-            "type": "link",
-            "title": null,
-            "url": "https://github.com/adobe/hypermedia-pipeline/blob/master/LICENSE.txt",
-            "children": [
-              {
-                "type": "image",
-                "title": null,
-                "url": "https://img.shields.io/github/license/adobe/hypermedia-pipeline.svg",
-                "alt": "GitHub license"
-              }
-            ]
-          },
-          {
-            "type": "text",
-            "value": "\n"
-          },
-          {
-            "type": "link",
-            "title": null,
-            "url": "https://github.com/adobe/hypermedia-pipeline/issues",
-            "children": [
-              {
-                "type": "image",
-                "title": null,
-                "url": "https://img.shields.io/github/issues/adobe/hypermedia-pipeline.svg",
-                "alt": "GitHub issues"
-              }
-            ]
-          },
-          {
-            "type": "text",
-            "value": "\n"
-          },
-          {
-            "type": "link",
-            "title": null,
-            "url": "https://www.npmjs.com/package/@adobe/hypermedia-pipeline",
-            "children": [
-              {
-                "type": "image",
-                "title": null,
-                "url": "https://img.shields.io/npm/dw/@adobe/hypermedia-pipeline.svg",
-                "alt": "npm"
-              }
-            ]
-          },
-          {
-            "type": "text",
-            "value": " "
-          },
-          {
-            "type": "link",
-            "title": null,
-            "url": "https://greenkeeper.io/",
-            "children": [
-              {
-                "type": "image",
-                "title": null,
-                "url": "https://badges.greenkeeper.io/adobe/hypermedia-pipeline.svg",
-                "alt": "Greenkeeper badge"
-              }
+        {
+          "type": "heading",
+          "depth": 1,
+          "children": [
+            {
+              "type": "text",
+              "value": "Hypermedia Pipeline"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-heading"
             ]
           }
-        ],
-        "data": {
-          "types": [
-            "has-link",
-            "is-text"
-          ]
-        }
-      }
-    ]
-  },
-  {
-    "types": [
-      "has-text",
-      "has-inlineCode",
-      "has-list",
-      "has-heading",
-      "nb-text-4",
-      "nb-inlineCode-2",
-      "nb-list-1",
-      "nb-heading-1",
-      "is-text-inlineCode-list",
-      "is-text-inlineCode",
-      "is-text"
-    ],
-    "intro": "A pipeline consists of following main parts:",
-    "title": "Anatomy of a Pipeline",
-    "meta": {
-      "class": "section"
-    },
-    "type": "root",
-    "children": [
-      {
-        "type": "yaml",
-        "payload": {
-          "class": "section"
         },
-        "data": {
-          "types": []
-        }
-      },
-      {
-        "type": "heading",
-        "depth": 2,
-        "children": [
-          {
-            "type": "text",
-            "value": "Anatomy of a Pipeline"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-heading"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "A pipeline consists of following main parts:"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text"
-          ]
-        }
-      },
-      {
-        "type": "list",
-        "ordered": false,
-        "start": null,
-        "spread": false,
-        "children": [
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "text",
-                    "value": "pre-processing functions"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "is-text"
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "text",
-                    "value": "the main response generating function"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "is-text"
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "text",
-                    "value": "an optional wrapper function"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "is-text"
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "text",
-                    "value": "post-processing functions"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "is-text"
-                  ]
-                }
-              }
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "This project provides helper functions and default implementations for creating Hypermedia Processing Pipelines."
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text"
             ]
           }
-        ],
-        "data": {
-          "types": [
-            "has-text",
-            "nb-text-4",
-            "has-only-text",
-            "is-list"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "Each step of the pipeline is processing a single payload object, that will slowly accumulate the "
-          },
-          {
-            "type": "inlineCode",
-            "value": "return"
-          },
-          {
-            "type": "text",
-            "value": " values of the functions above through "
-          },
-          {
-            "type": "inlineCode",
-            "value": "Object.assign"
-          },
-          {
-            "type": "text",
-            "value": "."
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text",
-            "has-inlineCode"
-          ]
-        }
-      }
-    ]
-  },
-  {
-    "title": "This section has a paragraph, but no title.",
-    "types": [
-      "has-text",
-      "nb-text-2",
-      "has-only-text"
-    ],
-    "intro": "This section has a paragraph, but no title.",
-    "meta": {},
-    "type": "root",
-    "children": [
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "This section has a paragraph, but no title."
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "Tough luck."
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text"
-          ]
-        }
-      }
-    ]
-  },
-  {
-    "intro": "This section has a title, but no paragraph",
-    "types": [
-      "has-heading",
-      "nb-heading-1",
-      "has-only-heading"
-    ],
-    "title": "This section has a title, but no paragraph",
-    "meta": {},
-    "type": "root",
-    "children": [
-      {
-        "type": "heading",
-        "depth": 2,
-        "children": [
-          {
-            "type": "text",
-            "value": "This section has a title, but no paragraph"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-heading"
-          ]
-        }
-      }
-    ]
-  },
-  {
-    "title": "See below for the anatomy of a payload.",
-    "types": [
-      "has-list",
-      "has-text",
-      "nb-list-1",
-      "nb-text-2",
-      "is-text-list",
-      "is-text"
-    ],
-    "intro": "See below for the anatomy of a payload.",
-    "meta": {},
-    "type": "root",
-    "children": [
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "See below for the anatomy of a payload."
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "Typically, there is one pipeline for each content type supported and pipeline are identified by file name, e.g."
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text"
-          ]
-        }
-      },
-      {
-        "type": "list",
-        "ordered": false,
-        "start": null,
-        "spread": false,
-        "children": [
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "html.pipe.js"
-                  },
-                  {
-                    "type": "text",
-                    "value": " – creates HTML documents with the "
-                  },
-                  {
-                    "type": "inlineCode",
-                    "value": "text/html"
-                  },
-                  {
-                    "type": "text",
-                    "value": " content-type"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "is-text"
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "json.pipe.js"
-                  },
-                  {
-                    "type": "text",
-                    "value": " – creates JSON documents with the "
-                  },
-                  {
-                    "type": "inlineCode",
-                    "value": "application/json"
-                  },
-                  {
-                    "type": "text",
-                    "value": " content-type"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "is-text"
-                  ]
-                }
-              }
-            ]
-          }
-        ],
-        "data": {
-          "types": [
-            "has-inlineCode",
-            "has-text",
-            "nb-inlineCode-4",
-            "nb-text-4",
-            "is-inlineCode-text",
-            "is-inlineCode",
-            "is-list"
-          ]
-        }
-      }
-    ]
-  },
-  {
-    "types": [
-      "has-text",
-      "has-inlineCode",
-      "has-code",
-      "has-list",
-      "has-heading",
-      "nb-text-6",
-      "nb-inlineCode-3",
-      "nb-code-1",
-      "nb-list-1",
-      "nb-heading-1",
-      "is-text-inlineCode-code",
-      "is-text-inlineCode",
-      "is-text"
-    ],
-    "intro": "A pipeline builder can be created by creating a CommonJS module that exports a function pipe which accepts following arguments and returns a Pipeline function.",
-    "title": "Building a Pipeline",
-    "meta": {
-      "class": "code"
-    },
-    "type": "root",
-    "children": [
-      {
-        "type": "yaml",
-        "payload": {
-          "class": "code"
         },
-        "data": {
-          "types": []
-        }
-      },
-      {
-        "type": "heading",
-        "depth": 3,
-        "children": [
-          {
-            "type": "text",
-            "value": "Building a Pipeline"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-heading"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "A pipeline builder can be created by creating a CommonJS module that exports a function "
-          },
-          {
-            "type": "inlineCode",
-            "value": "pipe"
-          },
-          {
-            "type": "text",
-            "value": " which accepts following arguments and returns a Pipeline function."
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text",
-            "has-inlineCode"
-          ]
-        }
-      },
-      {
-        "type": "list",
-        "ordered": false,
-        "start": null,
-        "spread": false,
-        "children": [
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "cont"
-                  },
-                  {
-                    "type": "text",
-                    "value": ": the main function that will be executed as a continuation of the pipeline"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "is-text"
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "params"
-                  },
-                  {
-                    "type": "text",
-                    "value": ": a map of parameters that are interpreted at runtime"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "is-text"
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "secrets"
-                  },
-                  {
-                    "type": "text",
-                    "value": ": a map of protected configuration parameters like API keys that should be handled with care. By convention, all keys in "
-                  },
-                  {
-                    "type": "inlineCode",
-                    "value": "secret"
-                  },
-                  {
-                    "type": "text",
-                    "value": " are in ALL_CAPS_SNAKE_CASE."
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "is-text"
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "logger"
-                  },
-                  {
-                    "type": "text",
-                    "value": ": a "
-                  },
-                  {
-                    "type": "link",
-                    "title": null,
-                    "url": "https://www.github.com/winstonjs/winston",
-                    "children": [
-                      {
-                        "type": "text",
-                        "value": "Winston"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "text",
-                    "value": " logger"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "is-text",
-                    "has-link"
-                  ]
-                }
-              }
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "It uses reducers and continuations to create a simple processing pipeline that can pre-and post-process HTML, JSON, and other hypermedia."
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text"
             ]
           }
-        ],
-        "data": {
-          "types": [
-            "has-inlineCode",
-            "has-text",
-            "has-link",
-            "nb-inlineCode-5",
-            "nb-text-6",
-            "nb-link-1",
-            "is-text-inlineCode-link",
-            "is-text-inlineCode",
-            "is-text",
-            "is-list"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "This project's main entry provides a helper function for pipeline construction and a few helper functions, so that a basic pipeline can be constructed like this:"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text"
-          ]
-        }
-      },
-      {
-        "type": "code",
-        "lang": "javascript",
-        "meta": null,
-        "value": "// the pipeline itself\nconst pipeline = require(\"@adobe/hypermedia-pipeline\");\n// helper functions and log\nconst { adaptOWRequest, adaptOWResponse, log } = require('@adobe/hypermedia-pipeline/src/defaults/default.js');\n\nmodule.exports.pipe = function(cont, params, secrets, logger = log) {\n    logger.log(\"debug\", \"Constructing Custom Pipeline\");\n\n    return pipeline()\n        .pre(adaptOWRequest)   // optional: turns OpenWhisk-style arguments into a proper payload\n        .once(cont)            // required: execute the continuation function\n        .post(adaptOWResponse) // optional: turns the Payload into an OpenWhisk-style response\n}",
-        "data": {
-          "types": [
-            "is-code"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "In a typical pipeline, you will add additional processing steps as "
-          },
-          {
-            "type": "inlineCode",
-            "value": ".pre(require('some-module'))"
-          },
-          {
-            "type": "text",
-            "value": " or as "
-          },
-          {
-            "type": "inlineCode",
-            "value": ".post(require('some-module'))"
-          },
-          {
-            "type": "text",
-            "value": "."
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text",
-            "has-inlineCode"
-          ]
-        }
-      }
-    ]
-  },
-  {
-    "types": [
-      "has-list",
-      "has-text",
-      "has-inlineCode",
-      "has-heading",
-      "has-code",
-      "nb-list-9",
-      "nb-text-25",
-      "nb-inlineCode-11",
-      "nb-heading-10",
-      "nb-code-1",
-      "is-text-inlineCode-heading",
-      "is-text-inlineCode",
-      "is-text"
-    ],
-    "intro": "The main function is typically a pure function that converts the request, context, and content properties of the payload into a response object.",
-    "title": "The Main Function",
-    "meta": {},
-    "type": "root",
-    "children": [
-      {
-        "type": "heading",
-        "depth": 3,
-        "children": [
-          {
-            "type": "text",
-            "value": "The Main Function"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-heading"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "The main function is typically a pure function that converts the "
-          },
-          {
-            "type": "inlineCode",
-            "value": "request"
-          },
-          {
-            "type": "text",
-            "value": ", "
-          },
-          {
-            "type": "inlineCode",
-            "value": "context"
-          },
-          {
-            "type": "text",
-            "value": ", and "
-          },
-          {
-            "type": "inlineCode",
-            "value": "content"
-          },
-          {
-            "type": "text",
-            "value": " properties of the payload into a "
-          },
-          {
-            "type": "inlineCode",
-            "value": "response"
-          },
-          {
-            "type": "text",
-            "value": " object."
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text",
-            "has-inlineCode"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "In most scenarios, the main function is compiled from a template in a templating language like HTL, JST, or JSX."
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "Typically, there is one template (and thus one main function) for each content variation of the file type. Content variations are identified by a selector (the piece of the file name before the file extension, e.g. in "
-          },
-          {
-            "type": "inlineCode",
-            "value": "example.navigation.html"
-          },
-          {
-            "type": "text",
-            "value": " the selector would be "
-          },
-          {
-            "type": "inlineCode",
-            "value": "navigation"
-          },
-          {
-            "type": "text",
-            "value": "). If no selector is provided, the template is the default template for the pipeline."
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text",
-            "has-inlineCode"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "Examples of possible template names include:"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text"
-          ]
-        }
-      },
-      {
-        "type": "list",
-        "ordered": false,
-        "start": null,
-        "spread": false,
-        "children": [
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "html.jsx"
-                  },
-                  {
-                    "type": "text",
-                    "value": " (compiled to "
-                  },
-                  {
-                    "type": "inlineCode",
-                    "value": "html.js"
-                  },
-                  {
-                    "type": "text",
-                    "value": ") – default for the HTML pipeline"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "is-text"
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "html.navigation.jst"
-                  },
-                  {
-                    "type": "text",
-                    "value": " (compiled to "
-                  },
-                  {
-                    "type": "inlineCode",
-                    "value": "html.navigation.js"
-                  },
-                  {
-                    "type": "text",
-                    "value": ") – renders the navigation"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "is-text"
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "dropdown.json.js"
-                  },
-                  {
-                    "type": "text",
-                    "value": " (not compiled) – creates pure JSON output"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "is-text"
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "dropdown.html.htl"
-                  },
-                  {
-                    "type": "text",
-                    "value": " (compiled to "
-                  },
-                  {
-                    "type": "inlineCode",
-                    "value": "dropdown.html.js"
-                  },
-                  {
-                    "type": "text",
-                    "value": ") – renders the dropdown component"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "is-text"
-                  ]
-                }
-              }
+        },
+        {
+          "type": "heading",
+          "depth": 1,
+          "children": [
+            {
+              "type": "text",
+              "value": "Status"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-heading"
             ]
           }
-        ],
-        "data": {
-          "types": [
-            "has-inlineCode",
-            "has-text",
-            "nb-inlineCode-7",
-            "nb-text-7",
-            "is-inlineCode-text",
-            "is-inlineCode",
-            "is-list"
-          ]
-        }
-      },
-      {
-        "type": "heading",
-        "depth": 3,
-        "children": [
-          {
-            "type": "text",
-            "value": "(Optional) The Wrapper Function"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-heading"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "Sometimes it is neccessary to pre-process the payload in a template-specific fashion. This wrapper function (often called \"Pre-JS\" for brevity sake) allows the full transformation of the pipeline's payload."
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "Compared to the pipeline-specific pre-processing functions which handle the request, content, and response, the focus of the wrapper function is implementing business logic needed for the main template function. This allows for a clean separation between:"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text"
-          ]
-        }
-      },
-      {
-        "type": "list",
-        "ordered": true,
-        "start": 1,
-        "spread": false,
-        "children": [
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "text",
-                    "value": "presentation (in the main function, often expressed in declarative templates)"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "is-text"
-                  ]
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "link",
+              "title": null,
+              "url": "https://codecov.io/gh/adobe/hypermedia-pipeline",
+              "children": [
+                {
+                  "type": "image",
+                  "title": null,
+                  "url": "https://img.shields.io/codecov/c/github/adobe/hypermedia-pipeline.svg",
+                  "alt": "codecov"
                 }
-              }
+              ]
+            },
+            {
+              "type": "text",
+              "value": "\n"
+            },
+            {
+              "type": "link",
+              "title": null,
+              "url": "https://circleci.com/gh/adobe/parcel-plugin-htl",
+              "children": [
+                {
+                  "type": "image",
+                  "title": null,
+                  "url": "https://img.shields.io/circleci/project/github/adobe/hypermedia-pipeline.svg",
+                  "alt": "CircleCI"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "value": "\n"
+            },
+            {
+              "type": "link",
+              "title": null,
+              "url": "https://github.com/adobe/hypermedia-pipeline/blob/master/LICENSE.txt",
+              "children": [
+                {
+                  "type": "image",
+                  "title": null,
+                  "url": "https://img.shields.io/github/license/adobe/hypermedia-pipeline.svg",
+                  "alt": "GitHub license"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "value": "\n"
+            },
+            {
+              "type": "link",
+              "title": null,
+              "url": "https://github.com/adobe/hypermedia-pipeline/issues",
+              "children": [
+                {
+                  "type": "image",
+                  "title": null,
+                  "url": "https://img.shields.io/github/issues/adobe/hypermedia-pipeline.svg",
+                  "alt": "GitHub issues"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "value": "\n"
+            },
+            {
+              "type": "link",
+              "title": null,
+              "url": "https://www.npmjs.com/package/@adobe/hypermedia-pipeline",
+              "children": [
+                {
+                  "type": "image",
+                  "title": null,
+                  "url": "https://img.shields.io/npm/dw/@adobe/hypermedia-pipeline.svg",
+                  "alt": "npm"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "value": " "
+            },
+            {
+              "type": "link",
+              "title": null,
+              "url": "https://greenkeeper.io/",
+              "children": [
+                {
+                  "type": "image",
+                  "title": null,
+                  "url": "https://badges.greenkeeper.io/adobe/hypermedia-pipeline.svg",
+                  "alt": "Greenkeeper badge"
+                }
+              ]
+            }
+          ],
+          "data": {
+            "types": [
+              "has-link",
+              "is-text"
             ]
+          }
+        }
+      ]
+    },
+    {
+      "types": [
+        "has-text",
+        "has-inlineCode",
+        "has-list",
+        "has-heading",
+        "nb-text-4",
+        "nb-inlineCode-2",
+        "nb-list-1",
+        "nb-heading-1",
+        "is-text-inlineCode-list",
+        "is-text-inlineCode",
+        "is-text"
+      ],
+      "intro": "A pipeline consists of following main parts:",
+      "title": "Anatomy of a Pipeline",
+      "meta": {
+        "class": "section"
+      },
+      "type": "section",
+      "children": [
+        {
+          "type": "yaml",
+          "payload": {
+            "class": "section"
           },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "text",
-                    "value": "business logic (in the wrapper function, often expressed in imperative code)"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "is-text"
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "text",
-                    "value": "content-type specific implementation (in the pipeline, expressed in functional code)"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "is-text"
-                  ]
-                }
-              }
+          "data": {
+            "types": []
+          }
+        },
+        {
+          "type": "heading",
+          "depth": 2,
+          "children": [
+            {
+              "type": "text",
+              "value": "Anatomy of a Pipeline"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-heading"
             ]
           }
-        ],
-        "data": {
-          "types": [
-            "has-text",
-            "nb-text-3",
-            "has-only-text",
-            "is-list"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "A simple implementation of a wrapper function would look like this:"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text"
-          ]
-        }
-      },
-      {
-        "type": "code",
-        "lang": "javascript",
-        "meta": null,
-        "value": "// All wrapper functions must export `pre`\n// The functions takes following arguments:\n// - `cont` (the continuation function, i.e. the main template function)\n// - `payload` (the payload of the pipeline)\nmodule.exports.pre = (cont, payload) => {\n    const {request, content, context, response} = payload;\n    \n    // modifying the payload content before invoking the main function\n    content.hello = 'World';\n    const modifiedpayload = {request, content, context, response};\n\n    // invoking the main function with the new payload. Capturing the response\n    // payload for further modification\n\n    const responsepayload = cont(modifiedpayload);\n\n    // Adding a value to the payload response\n    const modifiedresponse = modifiedpayload.response;\n    modifiedresponse.hello = 'World';\n\n    return Object.assign(modifiedpayload, modifiedresponse);\n}",
-        "data": {
-          "types": [
-            "is-code"
-          ]
-        }
-      },
-      {
-        "type": "heading",
-        "depth": 3,
-        "children": [
-          {
-            "type": "text",
-            "value": "Pre-Processing Functions"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-heading"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "Pre-Processing functions are meant to:"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text"
-          ]
-        }
-      },
-      {
-        "type": "list",
-        "ordered": false,
-        "start": null,
-        "spread": false,
-        "children": [
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "text",
-                    "value": "parse and process request parameters"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "is-text"
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "text",
-                    "value": "fetch and parse the requested content"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "is-text"
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "text",
-                    "value": "transform the requested content"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "is-text"
-                  ]
-                }
-              }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "A pipeline consists of following main parts:"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text"
             ]
           }
-        ],
-        "data": {
-          "types": [
-            "has-text",
-            "nb-text-3",
-            "has-only-text",
-            "is-list"
-          ]
-        }
-      },
-      {
-        "type": "heading",
-        "depth": 3,
-        "children": [
-          {
-            "type": "text",
-            "value": "Post-Processing Functions"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-heading"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "Post-Processing functions are meant to:"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text"
-          ]
-        }
-      },
-      {
-        "type": "list",
-        "ordered": false,
-        "start": null,
-        "spread": false,
-        "children": [
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "text",
-                    "value": "process and transform the response"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "is-text"
-                  ]
-                }
-              }
-            ]
-          }
-        ],
-        "data": {
-          "types": [
-            "has-text",
-            "nb-text-1",
-            "has-only-text",
-            "is-list"
-          ]
-        }
-      },
-      {
-        "type": "heading",
-        "depth": 2,
-        "children": [
-          {
-            "type": "text",
-            "value": "Anatomy of the Payload"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-heading"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "Following main properties exist:"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text"
-          ]
-        }
-      },
-      {
-        "type": "list",
-        "ordered": false,
-        "start": null,
-        "spread": false,
-        "children": [
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "request"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode"
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "content"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode"
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "response"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode"
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "context"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode"
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "error"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode"
-                  ]
-                }
-              }
-            ]
-          }
-        ],
-        "data": {
-          "types": [
-            "has-inlineCode",
-            "nb-inlineCode-5",
-            "has-only-inlineCode",
-            "is-list"
-          ]
-        }
-      },
-      {
-        "type": "heading",
-        "depth": 3,
-        "children": [
-          {
-            "type": "text",
-            "value": "The "
-          },
-          {
-            "type": "inlineCode",
-            "value": "request"
-          },
-          {
-            "type": "text",
-            "value": " object"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-heading"
-          ]
-        }
-      },
-      {
-        "type": "list",
-        "ordered": false,
-        "start": null,
-        "spread": false,
-        "children": [
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "params"
-                  },
-                  {
-                    "type": "text",
-                    "value": ": a map of request parameters"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "is-text"
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "headers"
-                  },
-                  {
-                    "type": "text",
-                    "value": ": a map of HTTP headers"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "is-text"
-                  ]
-                }
-              }
-            ]
-          }
-        ],
-        "data": {
-          "types": [
-            "has-inlineCode",
-            "has-text",
-            "nb-inlineCode-2",
-            "nb-text-2",
-            "is-inlineCode-text",
-            "is-inlineCode",
-            "is-list"
-          ]
-        }
-      },
-      {
-        "type": "heading",
-        "depth": 3,
-        "children": [
-          {
-            "type": "text",
-            "value": "The "
-          },
-          {
-            "type": "inlineCode",
-            "value": "content"
-          },
-          {
-            "type": "text",
-            "value": " object"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-heading"
-          ]
-        }
-      },
-      {
-        "type": "list",
-        "ordered": false,
-        "start": null,
-        "spread": false,
-        "children": [
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "body"
-                  },
-                  {
-                    "type": "text",
-                    "value": ": the unparsed content body as a "
-                  },
-                  {
-                    "type": "inlineCode",
-                    "value": "string"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "is-text"
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "mdast"
-                  },
-                  {
-                    "type": "text",
-                    "value": ": the parsed "
-                  },
-                  {
-                    "type": "link",
-                    "title": null,
-                    "url": "https://github.com/syntax-tree/mdast",
-                    "children": [
-                      {
-                        "type": "text",
-                        "value": "Markdown AST"
-                      }
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "start": null,
+          "spread": false,
+          "children": [
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "pre-processing functions"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "is-text"
                     ]
                   }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "is-text",
-                    "has-link"
-                  ]
                 }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "meta"
-                  },
-                  {
-                    "type": "text",
-                    "value": ": a map metadata properties, including"
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "the main response generating function"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "is-text"
+                    ]
                   }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "is-text"
-                  ]
                 }
-              },
-              {
-                "type": "list",
-                "ordered": false,
-                "start": null,
-                "spread": false,
-                "children": [
-                  {
-                    "type": "listItem",
-                    "spread": false,
-                    "checked": null,
-                    "children": [
-                      {
-                        "type": "paragraph",
-                        "children": [
-                          {
-                            "type": "inlineCode",
-                            "value": "title"
-                          },
-                          {
-                            "type": "text",
-                            "value": ": title of the document"
-                          }
-                        ],
-                        "data": {
-                          "types": [
-                            "has-inlineCode",
-                            "is-text"
-                          ]
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "an optional wrapper function"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "is-text"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "post-processing functions"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "is-text"
+                    ]
+                  }
+                }
+              ]
+            }
+          ],
+          "data": {
+            "types": [
+              "has-text",
+              "nb-text-4",
+              "has-only-text",
+              "is-list"
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Each step of the pipeline is processing a single payload object, that will slowly accumulate the "
+            },
+            {
+              "type": "inlineCode",
+              "value": "return"
+            },
+            {
+              "type": "text",
+              "value": " values of the functions above through "
+            },
+            {
+              "type": "inlineCode",
+              "value": "Object.assign"
+            },
+            {
+              "type": "text",
+              "value": "."
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text",
+              "has-inlineCode"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "title": "This section has a paragraph, but no title.",
+      "types": [
+        "has-text",
+        "nb-text-2",
+        "has-only-text"
+      ],
+      "intro": "This section has a paragraph, but no title.",
+      "meta": {},
+      "type": "section",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "This section has a paragraph, but no title."
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text"
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Tough luck."
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "intro": "This section has a title, but no paragraph",
+      "types": [
+        "has-heading",
+        "nb-heading-1",
+        "has-only-heading"
+      ],
+      "title": "This section has a title, but no paragraph",
+      "meta": {},
+      "type": "section",
+      "children": [
+        {
+          "type": "heading",
+          "depth": 2,
+          "children": [
+            {
+              "type": "text",
+              "value": "This section has a title, but no paragraph"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-heading"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "title": "See below for the anatomy of a payload.",
+      "types": [
+        "has-list",
+        "has-text",
+        "nb-list-1",
+        "nb-text-2",
+        "is-text-list",
+        "is-text"
+      ],
+      "intro": "See below for the anatomy of a payload.",
+      "meta": {},
+      "type": "section",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "See below for the anatomy of a payload."
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text"
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Typically, there is one pipeline for each content type supported and pipeline are identified by file name, e.g."
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text"
+            ]
+          }
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "start": null,
+          "spread": false,
+          "children": [
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "html.pipe.js"
+                    },
+                    {
+                      "type": "text",
+                      "value": " – creates HTML documents with the "
+                    },
+                    {
+                      "type": "inlineCode",
+                      "value": "text/html"
+                    },
+                    {
+                      "type": "text",
+                      "value": " content-type"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "is-text"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "json.pipe.js"
+                    },
+                    {
+                      "type": "text",
+                      "value": " – creates JSON documents with the "
+                    },
+                    {
+                      "type": "inlineCode",
+                      "value": "application/json"
+                    },
+                    {
+                      "type": "text",
+                      "value": " content-type"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "is-text"
+                    ]
+                  }
+                }
+              ]
+            }
+          ],
+          "data": {
+            "types": [
+              "has-inlineCode",
+              "has-text",
+              "nb-inlineCode-4",
+              "nb-text-4",
+              "is-inlineCode-text",
+              "is-inlineCode",
+              "is-list"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "types": [
+        "has-text",
+        "has-inlineCode",
+        "has-code",
+        "has-list",
+        "has-heading",
+        "nb-text-6",
+        "nb-inlineCode-3",
+        "nb-code-1",
+        "nb-list-1",
+        "nb-heading-1",
+        "is-text-inlineCode-code",
+        "is-text-inlineCode",
+        "is-text"
+      ],
+      "intro": "A pipeline builder can be created by creating a CommonJS module that exports a function pipe which accepts following arguments and returns a Pipeline function.",
+      "title": "Building a Pipeline",
+      "meta": {
+        "class": "code"
+      },
+      "type": "section",
+      "children": [
+        {
+          "type": "yaml",
+          "payload": {
+            "class": "code"
+          },
+          "data": {
+            "types": []
+          }
+        },
+        {
+          "type": "heading",
+          "depth": 3,
+          "children": [
+            {
+              "type": "text",
+              "value": "Building a Pipeline"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-heading"
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "A pipeline builder can be created by creating a CommonJS module that exports a function "
+            },
+            {
+              "type": "inlineCode",
+              "value": "pipe"
+            },
+            {
+              "type": "text",
+              "value": " which accepts following arguments and returns a Pipeline function."
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text",
+              "has-inlineCode"
+            ]
+          }
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "start": null,
+          "spread": false,
+          "children": [
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "cont"
+                    },
+                    {
+                      "type": "text",
+                      "value": ": the main function that will be executed as a continuation of the pipeline"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "is-text"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "params"
+                    },
+                    {
+                      "type": "text",
+                      "value": ": a map of parameters that are interpreted at runtime"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "is-text"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "secrets"
+                    },
+                    {
+                      "type": "text",
+                      "value": ": a map of protected configuration parameters like API keys that should be handled with care. By convention, all keys in "
+                    },
+                    {
+                      "type": "inlineCode",
+                      "value": "secret"
+                    },
+                    {
+                      "type": "text",
+                      "value": " are in ALL_CAPS_SNAKE_CASE."
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "is-text"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "logger"
+                    },
+                    {
+                      "type": "text",
+                      "value": ": a "
+                    },
+                    {
+                      "type": "link",
+                      "title": null,
+                      "url": "https://www.github.com/winstonjs/winston",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "Winston"
                         }
-                      }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "value": " logger"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "is-text",
+                      "has-link"
                     ]
-                  },
-                  {
-                    "type": "listItem",
-                    "spread": false,
-                    "checked": null,
-                    "children": [
-                      {
-                        "type": "paragraph",
-                        "children": [
-                          {
-                            "type": "inlineCode",
-                            "value": "intro"
-                          },
-                          {
-                            "type": "text",
-                            "value": ": a plain-text introduction or description"
-                          }
-                        ],
-                        "data": {
-                          "types": [
-                            "has-inlineCode",
-                            "is-text"
-                          ]
+                  }
+                }
+              ]
+            }
+          ],
+          "data": {
+            "types": [
+              "has-inlineCode",
+              "has-text",
+              "has-link",
+              "nb-inlineCode-5",
+              "nb-text-6",
+              "nb-link-1",
+              "is-text-inlineCode-link",
+              "is-text-inlineCode",
+              "is-text",
+              "is-list"
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "This project's main entry provides a helper function for pipeline construction and a few helper functions, so that a basic pipeline can be constructed like this:"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text"
+            ]
+          }
+        },
+        {
+          "type": "code",
+          "lang": "javascript",
+          "meta": null,
+          "value": "// the pipeline itself\nconst pipeline = require(\"@adobe/hypermedia-pipeline\");\n// helper functions and log\nconst { adaptOWRequest, adaptOWResponse, log } = require('@adobe/hypermedia-pipeline/src/defaults/default.js');\n\nmodule.exports.pipe = function(cont, params, secrets, logger = log) {\n    logger.log(\"debug\", \"Constructing Custom Pipeline\");\n\n    return pipeline()\n        .pre(adaptOWRequest)   // optional: turns OpenWhisk-style arguments into a proper payload\n        .once(cont)            // required: execute the continuation function\n        .post(adaptOWResponse) // optional: turns the Payload into an OpenWhisk-style response\n}",
+          "data": {
+            "types": [
+              "is-code"
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "In a typical pipeline, you will add additional processing steps as "
+            },
+            {
+              "type": "inlineCode",
+              "value": ".pre(require('some-module'))"
+            },
+            {
+              "type": "text",
+              "value": " or as "
+            },
+            {
+              "type": "inlineCode",
+              "value": ".post(require('some-module'))"
+            },
+            {
+              "type": "text",
+              "value": "."
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text",
+              "has-inlineCode"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "types": [
+        "has-list",
+        "has-text",
+        "has-inlineCode",
+        "has-heading",
+        "has-code",
+        "nb-list-9",
+        "nb-text-25",
+        "nb-inlineCode-11",
+        "nb-heading-10",
+        "nb-code-1",
+        "is-text-inlineCode-heading",
+        "is-text-inlineCode",
+        "is-text"
+      ],
+      "intro": "The main function is typically a pure function that converts the request, context, and content properties of the payload into a response object.",
+      "title": "The Main Function",
+      "meta": {},
+      "type": "section",
+      "children": [
+        {
+          "type": "heading",
+          "depth": 3,
+          "children": [
+            {
+              "type": "text",
+              "value": "The Main Function"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-heading"
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "The main function is typically a pure function that converts the "
+            },
+            {
+              "type": "inlineCode",
+              "value": "request"
+            },
+            {
+              "type": "text",
+              "value": ", "
+            },
+            {
+              "type": "inlineCode",
+              "value": "context"
+            },
+            {
+              "type": "text",
+              "value": ", and "
+            },
+            {
+              "type": "inlineCode",
+              "value": "content"
+            },
+            {
+              "type": "text",
+              "value": " properties of the payload into a "
+            },
+            {
+              "type": "inlineCode",
+              "value": "response"
+            },
+            {
+              "type": "text",
+              "value": " object."
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text",
+              "has-inlineCode"
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "In most scenarios, the main function is compiled from a template in a templating language like HTL, JST, or JSX."
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text"
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Typically, there is one template (and thus one main function) for each content variation of the file type. Content variations are identified by a selector (the piece of the file name before the file extension, e.g. in "
+            },
+            {
+              "type": "inlineCode",
+              "value": "example.navigation.html"
+            },
+            {
+              "type": "text",
+              "value": " the selector would be "
+            },
+            {
+              "type": "inlineCode",
+              "value": "navigation"
+            },
+            {
+              "type": "text",
+              "value": "). If no selector is provided, the template is the default template for the pipeline."
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text",
+              "has-inlineCode"
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Examples of possible template names include:"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text"
+            ]
+          }
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "start": null,
+          "spread": false,
+          "children": [
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "html.jsx"
+                    },
+                    {
+                      "type": "text",
+                      "value": " (compiled to "
+                    },
+                    {
+                      "type": "inlineCode",
+                      "value": "html.js"
+                    },
+                    {
+                      "type": "text",
+                      "value": ") – default for the HTML pipeline"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "is-text"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "html.navigation.jst"
+                    },
+                    {
+                      "type": "text",
+                      "value": " (compiled to "
+                    },
+                    {
+                      "type": "inlineCode",
+                      "value": "html.navigation.js"
+                    },
+                    {
+                      "type": "text",
+                      "value": ") – renders the navigation"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "is-text"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "dropdown.json.js"
+                    },
+                    {
+                      "type": "text",
+                      "value": " (not compiled) – creates pure JSON output"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "is-text"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "dropdown.html.htl"
+                    },
+                    {
+                      "type": "text",
+                      "value": " (compiled to "
+                    },
+                    {
+                      "type": "inlineCode",
+                      "value": "dropdown.html.js"
+                    },
+                    {
+                      "type": "text",
+                      "value": ") – renders the dropdown component"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "is-text"
+                    ]
+                  }
+                }
+              ]
+            }
+          ],
+          "data": {
+            "types": [
+              "has-inlineCode",
+              "has-text",
+              "nb-inlineCode-7",
+              "nb-text-7",
+              "is-inlineCode-text",
+              "is-inlineCode",
+              "is-list"
+            ]
+          }
+        },
+        {
+          "type": "heading",
+          "depth": 3,
+          "children": [
+            {
+              "type": "text",
+              "value": "(Optional) The Wrapper Function"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-heading"
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Sometimes it is neccessary to pre-process the payload in a template-specific fashion. This wrapper function (often called \"Pre-JS\" for brevity sake) allows the full transformation of the pipeline's payload."
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text"
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Compared to the pipeline-specific pre-processing functions which handle the request, content, and response, the focus of the wrapper function is implementing business logic needed for the main template function. This allows for a clean separation between:"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text"
+            ]
+          }
+        },
+        {
+          "type": "list",
+          "ordered": true,
+          "start": 1,
+          "spread": false,
+          "children": [
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "presentation (in the main function, often expressed in declarative templates)"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "is-text"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "business logic (in the wrapper function, often expressed in imperative code)"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "is-text"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "content-type specific implementation (in the pipeline, expressed in functional code)"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "is-text"
+                    ]
+                  }
+                }
+              ]
+            }
+          ],
+          "data": {
+            "types": [
+              "has-text",
+              "nb-text-3",
+              "has-only-text",
+              "is-list"
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "A simple implementation of a wrapper function would look like this:"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text"
+            ]
+          }
+        },
+        {
+          "type": "code",
+          "lang": "javascript",
+          "meta": null,
+          "value": "// All wrapper functions must export `pre`\n// The functions takes following arguments:\n// - `cont` (the continuation function, i.e. the main template function)\n// - `payload` (the payload of the pipeline)\nmodule.exports.pre = (cont, payload) => {\n    const {request, content, context, response} = payload;\n    \n    // modifying the payload content before invoking the main function\n    content.hello = 'World';\n    const modifiedpayload = {request, content, context, response};\n\n    // invoking the main function with the new payload. Capturing the response\n    // payload for further modification\n\n    const responsepayload = cont(modifiedpayload);\n\n    // Adding a value to the payload response\n    const modifiedresponse = modifiedpayload.response;\n    modifiedresponse.hello = 'World';\n\n    return Object.assign(modifiedpayload, modifiedresponse);\n}",
+          "data": {
+            "types": [
+              "is-code"
+            ]
+          }
+        },
+        {
+          "type": "heading",
+          "depth": 3,
+          "children": [
+            {
+              "type": "text",
+              "value": "Pre-Processing Functions"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-heading"
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Pre-Processing functions are meant to:"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text"
+            ]
+          }
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "start": null,
+          "spread": false,
+          "children": [
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "parse and process request parameters"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "is-text"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "fetch and parse the requested content"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "is-text"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "transform the requested content"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "is-text"
+                    ]
+                  }
+                }
+              ]
+            }
+          ],
+          "data": {
+            "types": [
+              "has-text",
+              "nb-text-3",
+              "has-only-text",
+              "is-list"
+            ]
+          }
+        },
+        {
+          "type": "heading",
+          "depth": 3,
+          "children": [
+            {
+              "type": "text",
+              "value": "Post-Processing Functions"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-heading"
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Post-Processing functions are meant to:"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text"
+            ]
+          }
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "start": null,
+          "spread": false,
+          "children": [
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "process and transform the response"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "is-text"
+                    ]
+                  }
+                }
+              ]
+            }
+          ],
+          "data": {
+            "types": [
+              "has-text",
+              "nb-text-1",
+              "has-only-text",
+              "is-list"
+            ]
+          }
+        },
+        {
+          "type": "heading",
+          "depth": 2,
+          "children": [
+            {
+              "type": "text",
+              "value": "Anatomy of the Payload"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-heading"
+            ]
+          }
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Following main properties exist:"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text"
+            ]
+          }
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "start": null,
+          "spread": false,
+          "children": [
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "request"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "content"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "response"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "context"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "error"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode"
+                    ]
+                  }
+                }
+              ]
+            }
+          ],
+          "data": {
+            "types": [
+              "has-inlineCode",
+              "nb-inlineCode-5",
+              "has-only-inlineCode",
+              "is-list"
+            ]
+          }
+        },
+        {
+          "type": "heading",
+          "depth": 3,
+          "children": [
+            {
+              "type": "text",
+              "value": "The "
+            },
+            {
+              "type": "inlineCode",
+              "value": "request"
+            },
+            {
+              "type": "text",
+              "value": " object"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-heading"
+            ]
+          }
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "start": null,
+          "spread": false,
+          "children": [
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "params"
+                    },
+                    {
+                      "type": "text",
+                      "value": ": a map of request parameters"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "is-text"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "headers"
+                    },
+                    {
+                      "type": "text",
+                      "value": ": a map of HTTP headers"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "is-text"
+                    ]
+                  }
+                }
+              ]
+            }
+          ],
+          "data": {
+            "types": [
+              "has-inlineCode",
+              "has-text",
+              "nb-inlineCode-2",
+              "nb-text-2",
+              "is-inlineCode-text",
+              "is-inlineCode",
+              "is-list"
+            ]
+          }
+        },
+        {
+          "type": "heading",
+          "depth": 3,
+          "children": [
+            {
+              "type": "text",
+              "value": "The "
+            },
+            {
+              "type": "inlineCode",
+              "value": "content"
+            },
+            {
+              "type": "text",
+              "value": " object"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-heading"
+            ]
+          }
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "start": null,
+          "spread": false,
+          "children": [
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "body"
+                    },
+                    {
+                      "type": "text",
+                      "value": ": the unparsed content body as a "
+                    },
+                    {
+                      "type": "inlineCode",
+                      "value": "string"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "is-text"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "mdast"
+                    },
+                    {
+                      "type": "text",
+                      "value": ": the parsed "
+                    },
+                    {
+                      "type": "link",
+                      "title": null,
+                      "url": "https://github.com/syntax-tree/mdast",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "Markdown AST"
                         }
-                      }
+                      ]
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "is-text",
+                      "has-link"
                     ]
-                  },
-                  {
-                    "type": "listItem",
-                    "spread": false,
-                    "checked": null,
-                    "children": [
-                      {
-                        "type": "paragraph",
-                        "children": [
-                          {
-                            "type": "inlineCode",
-                            "value": "type"
-                          },
-                          {
-                            "type": "text",
-                            "value": ": the content type of the document"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "meta"
+                    },
+                    {
+                      "type": "text",
+                      "value": ": a map metadata properties, including"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "is-text"
+                    ]
+                  }
+                },
+                {
+                  "type": "list",
+                  "ordered": false,
+                  "start": null,
+                  "spread": false,
+                  "children": [
+                    {
+                      "type": "listItem",
+                      "spread": false,
+                      "checked": null,
+                      "children": [
+                        {
+                          "type": "paragraph",
+                          "children": [
+                            {
+                              "type": "inlineCode",
+                              "value": "title"
+                            },
+                            {
+                              "type": "text",
+                              "value": ": title of the document"
+                            }
+                          ],
+                          "data": {
+                            "types": [
+                              "has-inlineCode",
+                              "is-text"
+                            ]
                           }
-                        ],
-                        "data": {
-                          "types": [
-                            "has-inlineCode",
-                            "is-text"
-                          ]
                         }
-                      }
+                      ]
+                    },
+                    {
+                      "type": "listItem",
+                      "spread": false,
+                      "checked": null,
+                      "children": [
+                        {
+                          "type": "paragraph",
+                          "children": [
+                            {
+                              "type": "inlineCode",
+                              "value": "intro"
+                            },
+                            {
+                              "type": "text",
+                              "value": ": a plain-text introduction or description"
+                            }
+                          ],
+                          "data": {
+                            "types": [
+                              "has-inlineCode",
+                              "is-text"
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "listItem",
+                      "spread": false,
+                      "checked": null,
+                      "children": [
+                        {
+                          "type": "paragraph",
+                          "children": [
+                            {
+                              "type": "inlineCode",
+                              "value": "type"
+                            },
+                            {
+                              "type": "text",
+                              "value": ": the content type of the document"
+                            }
+                          ],
+                          "data": {
+                            "types": [
+                              "has-inlineCode",
+                              "is-text"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "has-text",
+                      "nb-inlineCode-3",
+                      "nb-text-3",
+                      "is-inlineCode-text",
+                      "is-inlineCode",
+                      "is-list"
                     ]
                   }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "has-text",
-                    "nb-inlineCode-3",
-                    "nb-text-3",
-                    "is-inlineCode-text",
-                    "is-inlineCode",
-                    "is-list"
-                  ]
                 }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "htast"
-                  },
-                  {
-                    "type": "text",
-                    "value": ": the HTML AST"
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "htast"
+                    },
+                    {
+                      "type": "text",
+                      "value": ": the HTML AST"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "is-text"
+                    ]
                   }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "is-text"
-                  ]
                 }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "html"
-                  },
-                  {
-                    "type": "text",
-                    "value": ": a string of the content rendered as HTML"
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "html"
+                    },
+                    {
+                      "type": "text",
+                      "value": ": a string of the content rendered as HTML"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "is-text"
+                    ]
                   }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "is-text"
-                  ]
                 }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "children"
-                  },
-                  {
-                    "type": "text",
-                    "value": ": an array of top-level elements of the HTML-rendered content"
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "children"
+                    },
+                    {
+                      "type": "text",
+                      "value": ": an array of top-level elements of the HTML-rendered content"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "is-text"
+                    ]
                   }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "is-text"
-                  ]
                 }
-              }
+              ]
+            }
+          ],
+          "data": {
+            "types": [
+              "has-inlineCode",
+              "has-text",
+              "has-list",
+              "has-link",
+              "nb-inlineCode-7",
+              "nb-text-6",
+              "nb-list-1",
+              "nb-link-1",
+              "is-inlineCode-text-list",
+              "is-inlineCode-text",
+              "is-inlineCode",
+              "is-list"
             ]
           }
-        ],
-        "data": {
-          "types": [
-            "has-inlineCode",
-            "has-text",
-            "has-list",
-            "has-link",
-            "nb-inlineCode-7",
-            "nb-text-6",
-            "nb-list-1",
-            "nb-link-1",
-            "is-inlineCode-text-list",
-            "is-inlineCode-text",
-            "is-inlineCode",
-            "is-list"
-          ]
-        }
-      },
-      {
-        "type": "heading",
-        "depth": 3,
-        "children": [
-          {
-            "type": "text",
-            "value": "The "
-          },
-          {
-            "type": "inlineCode",
-            "value": "response"
-          },
-          {
-            "type": "text",
-            "value": " object"
+        },
+        {
+          "type": "heading",
+          "depth": 3,
+          "children": [
+            {
+              "type": "text",
+              "value": "The "
+            },
+            {
+              "type": "inlineCode",
+              "value": "response"
+            },
+            {
+              "type": "text",
+              "value": " object"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-heading"
+            ]
           }
-        ],
-        "data": {
-          "types": [
-            "is-heading"
-          ]
-        }
-      },
-      {
-        "type": "list",
-        "ordered": false,
-        "start": null,
-        "spread": false,
-        "children": [
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "body"
-                  },
-                  {
-                    "type": "text",
-                    "value": ": the unparsed response body as a "
-                  },
-                  {
-                    "type": "inlineCode",
-                    "value": "string"
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "start": null,
+          "spread": false,
+          "children": [
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "body"
+                    },
+                    {
+                      "type": "text",
+                      "value": ": the unparsed response body as a "
+                    },
+                    {
+                      "type": "inlineCode",
+                      "value": "string"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "is-text"
+                    ]
                   }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "is-text"
-                  ]
                 }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "headers"
-                  },
-                  {
-                    "type": "text",
-                    "value": ": a map of HTTP response headers"
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "headers"
+                    },
+                    {
+                      "type": "text",
+                      "value": ": a map of HTTP response headers"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "is-text"
+                    ]
                   }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "is-text"
-                  ]
                 }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "status"
-                  },
-                  {
-                    "type": "text",
-                    "value": ": the HTTP status code"
+              ]
+            },
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "status"
+                    },
+                    {
+                      "type": "text",
+                      "value": ": the HTTP status code"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "is-text"
+                    ]
                   }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "is-text"
-                  ]
                 }
-              }
+              ]
+            }
+          ],
+          "data": {
+            "types": [
+              "has-inlineCode",
+              "has-text",
+              "nb-inlineCode-4",
+              "nb-text-3",
+              "is-inlineCode-text",
+              "is-inlineCode",
+              "is-list"
             ]
           }
-        ],
-        "data": {
-          "types": [
-            "has-inlineCode",
-            "has-text",
-            "nb-inlineCode-4",
-            "nb-text-3",
-            "is-inlineCode-text",
-            "is-inlineCode",
-            "is-list"
-          ]
-        }
-      },
-      {
-        "type": "heading",
-        "depth": 3,
-        "children": [
-          {
-            "type": "text",
-            "value": "The "
-          },
-          {
-            "type": "inlineCode",
-            "value": "context"
-          },
-          {
-            "type": "text",
-            "value": " object"
+        },
+        {
+          "type": "heading",
+          "depth": 3,
+          "children": [
+            {
+              "type": "text",
+              "value": "The "
+            },
+            {
+              "type": "inlineCode",
+              "value": "context"
+            },
+            {
+              "type": "text",
+              "value": " object"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-heading"
+            ]
           }
-        ],
-        "data": {
-          "types": [
-            "is-heading"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "TBD: used for stuff that is neither content, request, or response"
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "TBD: used for stuff that is neither content, request, or response"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text"
+            ]
           }
-        ],
-        "data": {
-          "types": [
-            "is-text"
-          ]
-        }
-      },
-      {
-        "type": "heading",
-        "depth": 3,
-        "children": [
-          {
-            "type": "text",
-            "value": "The "
-          },
-          {
-            "type": "inlineCode",
-            "value": "error"
-          },
-          {
-            "type": "text",
-            "value": " object"
+        },
+        {
+          "type": "heading",
+          "depth": 3,
+          "children": [
+            {
+              "type": "text",
+              "value": "The "
+            },
+            {
+              "type": "inlineCode",
+              "value": "error"
+            },
+            {
+              "type": "text",
+              "value": " object"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-heading"
+            ]
           }
-        ],
-        "data": {
-          "types": [
-            "is-heading"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "This object is only set when there has been an error during pipeline processing. Any step in the pipeline may set the "
-          },
-          {
-            "type": "inlineCode",
-            "value": "error"
-          },
-          {
-            "type": "text",
-            "value": " object. Subsequent steps should simply skip any processing if they encounter an "
-          },
-          {
-            "type": "inlineCode",
-            "value": "error"
-          },
-          {
-            "type": "text",
-            "value": " object."
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "This object is only set when there has been an error during pipeline processing. Any step in the pipeline may set the "
+            },
+            {
+              "type": "inlineCode",
+              "value": "error"
+            },
+            {
+              "type": "text",
+              "value": " object. Subsequent steps should simply skip any processing if they encounter an "
+            },
+            {
+              "type": "inlineCode",
+              "value": "error"
+            },
+            {
+              "type": "text",
+              "value": " object."
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text",
+              "has-inlineCode"
+            ]
           }
-        ],
-        "data": {
-          "types": [
-            "is-text",
-            "has-inlineCode"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "Alternatively, steps can attempt to handle the "
-          },
-          {
-            "type": "inlineCode",
-            "value": "error"
-          },
-          {
-            "type": "text",
-            "value": " object, for instance by generating a formatted error message and leaving it in "
-          },
-          {
-            "type": "inlineCode",
-            "value": "response.body"
-          },
-          {
-            "type": "text",
-            "value": "."
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Alternatively, steps can attempt to handle the "
+            },
+            {
+              "type": "inlineCode",
+              "value": "error"
+            },
+            {
+              "type": "text",
+              "value": " object, for instance by generating a formatted error message and leaving it in "
+            },
+            {
+              "type": "inlineCode",
+              "value": "response.body"
+            },
+            {
+              "type": "text",
+              "value": "."
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text",
+              "has-inlineCode"
+            ]
           }
-        ],
-        "data": {
-          "types": [
-            "is-text",
-            "has-inlineCode"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "The only known property in "
-          },
-          {
-            "type": "inlineCode",
-            "value": "error"
-          },
-          {
-            "type": "text",
-            "value": " is"
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "The only known property in "
+            },
+            {
+              "type": "inlineCode",
+              "value": "error"
+            },
+            {
+              "type": "text",
+              "value": " is"
+            }
+          ],
+          "data": {
+            "types": [
+              "is-text",
+              "has-inlineCode"
+            ]
           }
-        ],
-        "data": {
-          "types": [
-            "is-text",
-            "has-inlineCode"
-          ]
-        }
-      },
-      {
-        "type": "list",
-        "ordered": false,
-        "start": null,
-        "spread": false,
-        "children": [
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "inlineCode",
-                    "value": "message"
-                  },
-                  {
-                    "type": "text",
-                    "value": ": the error message"
+        },
+        {
+          "type": "list",
+          "ordered": false,
+          "start": null,
+          "spread": false,
+          "children": [
+            {
+              "type": "listItem",
+              "spread": false,
+              "checked": null,
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "inlineCode",
+                      "value": "message"
+                    },
+                    {
+                      "type": "text",
+                      "value": ": the error message"
+                    }
+                  ],
+                  "data": {
+                    "types": [
+                      "has-inlineCode",
+                      "is-text"
+                    ]
                   }
-                ],
-                "data": {
-                  "types": [
-                    "has-inlineCode",
-                    "is-text"
-                  ]
                 }
-              }
+              ]
+            }
+          ],
+          "data": {
+            "types": [
+              "has-inlineCode",
+              "has-text",
+              "nb-inlineCode-1",
+              "nb-text-1",
+              "is-inlineCode-text",
+              "is-inlineCode",
+              "is-list"
             ]
           }
-        ],
-        "data": {
-          "types": [
-            "has-inlineCode",
-            "has-text",
-            "nb-inlineCode-1",
-            "nb-text-1",
-            "is-inlineCode-text",
-            "is-inlineCode",
-            "is-list"
-          ]
         }
-      }
-    ]
-  }
-]
+      ]
+    }
+  ]
+}

--- a/test/fixtures/sections/header.json
+++ b/test/fixtures/sections/header.json
@@ -1,30 +1,28 @@
-[
-  {
-    "intro": "Header only",
-    "types": [
-      "has-heading",
-      "nb-heading-1",
-      "has-only-heading"
-    ],
-    "title": "Header only",
-    "meta": {},
-    "type": "root",
-    "children": [
-      {
-        "type": "heading",
-        "depth": 1,
-        "children": [
-          {
-            "type": "text",
-            "value": "Header only"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-heading"
-          ]
+{
+  "intro": "Header only",
+  "types": [
+    "has-heading",
+    "nb-heading-1",
+    "has-only-heading"
+  ],
+  "title": "Header only",
+  "meta": {},
+  "type": "root",
+  "children": [
+    {
+      "type": "heading",
+      "depth": 1,
+      "children": [
+        {
+          "type": "text",
+          "value": "Header only"
         }
+      ],
+      "data": {
+        "types": [
+          "is-heading"
+        ]
       }
-    ]
-  }
-]
+    }
+  ]
+}

--- a/test/fixtures/sections/headerimage.json
+++ b/test/fixtures/sections/headerimage.json
@@ -1,50 +1,48 @@
-[
-  {
-    "intro": "Header and one image",
-    "types": [
-      "has-image",
-      "has-heading",
-      "nb-image-1",
-      "nb-heading-1",
-      "is-image-heading",
-      "is-image"
-    ],
-    "image": "./helix_logo.png",
-    "title": "Header and one image",
-    "meta": {},
-    "type": "root",
-    "children": [
-      {
-        "type": "heading",
-        "depth": 1,
-        "children": [
-          {
-            "type": "text",
-            "value": "Header and one image"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-heading"
-          ]
+{
+  "intro": "Header and one image",
+  "types": [
+    "has-image",
+    "has-heading",
+    "nb-image-1",
+    "nb-heading-1",
+    "is-image-heading",
+    "is-image"
+  ],
+  "image": "./helix_logo.png",
+  "title": "Header and one image",
+  "meta": {},
+  "type": "root",
+  "children": [
+    {
+      "type": "heading",
+      "depth": 1,
+      "children": [
+        {
+          "type": "text",
+          "value": "Header and one image"
         }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "image",
-            "title": null,
-            "url": "./helix_logo.png",
-            "alt": "helix-logo"
-          }
-        ],
-        "data": {
-          "types": [
-            "has-image"
-          ]
-        }
+      ],
+      "data": {
+        "types": [
+          "is-heading"
+        ]
       }
-    ]
-  }
-]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "image",
+          "title": null,
+          "url": "./helix_logo.png",
+          "alt": "helix-logo"
+        }
+      ],
+      "data": {
+        "types": [
+          "has-image"
+        ]
+      }
+    }
+  ]
+}

--- a/test/fixtures/sections/headerlist.json
+++ b/test/fixtures/sections/headerlist.json
@@ -1,112 +1,110 @@
-[
-  {
-    "types": [
-      "has-list",
-      "has-heading",
-      "nb-list-1",
-      "nb-heading-1",
-      "is-list-heading",
-      "is-list"
-    ],
-    "intro": "list item 1",
-    "title": "Header and a list",
-    "meta": {},
-    "type": "root",
-    "children": [
-      {
-        "type": "heading",
-        "depth": 1,
-        "children": [
-          {
-            "type": "text",
-            "value": "Header and a list"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-heading"
-          ]
+{
+  "types": [
+    "has-list",
+    "has-heading",
+    "nb-list-1",
+    "nb-heading-1",
+    "is-list-heading",
+    "is-list"
+  ],
+  "intro": "list item 1",
+  "title": "Header and a list",
+  "meta": {},
+  "type": "root",
+  "children": [
+    {
+      "type": "heading",
+      "depth": 1,
+      "children": [
+        {
+          "type": "text",
+          "value": "Header and a list"
         }
-      },
-      {
-        "type": "list",
-        "ordered": false,
-        "start": null,
-        "spread": false,
-        "children": [
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "text",
-                    "value": "list item 1"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "is-text"
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "text",
-                    "value": "list item 2"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "is-text"
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "type": "listItem",
-            "spread": false,
-            "checked": null,
-            "children": [
-              {
-                "type": "paragraph",
-                "children": [
-                  {
-                    "type": "text",
-                    "value": "list item 3"
-                  }
-                ],
-                "data": {
-                  "types": [
-                    "is-text"
-                  ]
-                }
-              }
-            ]
-          }
-        ],
-        "data": {
-          "types": [
-            "has-text",
-            "nb-text-3",
-            "has-only-text",
-            "is-list"
-          ]
-        }
+      ],
+      "data": {
+        "types": [
+          "is-heading"
+        ]
       }
-    ]
-  }
-]
+    },
+    {
+      "type": "list",
+      "ordered": false,
+      "start": null,
+      "spread": false,
+      "children": [
+        {
+          "type": "listItem",
+          "spread": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "list item 1"
+                }
+              ],
+              "data": {
+                "types": [
+                  "is-text"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "listItem",
+          "spread": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "list item 2"
+                }
+              ],
+              "data": {
+                "types": [
+                  "is-text"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "listItem",
+          "spread": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "list item 3"
+                }
+              ],
+              "data": {
+                "types": [
+                  "is-text"
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "data": {
+        "types": [
+          "has-text",
+          "nb-text-3",
+          "has-only-text",
+          "is-list"
+        ]
+      }
+    }
+  ]
+}

--- a/test/fixtures/sections/headerpara2images.json
+++ b/test/fixtures/sections/headerpara2images.json
@@ -1,77 +1,75 @@
-[
-  {
-    "types": [
-      "has-image",
-      "has-text",
-      "has-heading",
-      "nb-image-2",
-      "nb-text-1",
-      "nb-heading-1",
-      "is-image-text-heading",
-      "is-image-text",
-      "is-image"
-    ],
-    "image": "./helix_logo.png",
-    "intro": "This is a paragraph.",
-    "title": "Header, a paragraph and one image",
-    "meta": {},
-    "type": "root",
-    "children": [
-      {
-        "type": "heading",
-        "depth": 1,
-        "children": [
-          {
-            "type": "text",
-            "value": "Header, a paragraph and one image"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-heading"
-          ]
+{
+  "types": [
+    "has-image",
+    "has-text",
+    "has-heading",
+    "nb-image-2",
+    "nb-text-1",
+    "nb-heading-1",
+    "is-image-text-heading",
+    "is-image-text",
+    "is-image"
+  ],
+  "image": "./helix_logo.png",
+  "intro": "This is a paragraph.",
+  "title": "Header, a paragraph and one image",
+  "meta": {},
+  "type": "root",
+  "children": [
+    {
+      "type": "heading",
+      "depth": 1,
+      "children": [
+        {
+          "type": "text",
+          "value": "Header, a paragraph and one image"
         }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "This is a paragraph."
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "image",
-            "title": null,
-            "url": "./helix_logo.png",
-            "alt": "helix-logo"
-          },
-          {
-            "type": "text",
-            "value": "\n"
-          },
-          {
-            "type": "image",
-            "title": null,
-            "url": "./helix_logo.png",
-            "alt": "helix-logo"
-          }
-        ],
-        "data": {
-          "types": [
-            "has-image"
-          ]
-        }
+      ],
+      "data": {
+        "types": [
+          "is-heading"
+        ]
       }
-    ]
-  }
-]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "This is a paragraph."
+        }
+      ],
+      "data": {
+        "types": [
+          "is-text"
+        ]
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "image",
+          "title": null,
+          "url": "./helix_logo.png",
+          "alt": "helix-logo"
+        },
+        {
+          "type": "text",
+          "value": "\n"
+        },
+        {
+          "type": "image",
+          "title": null,
+          "url": "./helix_logo.png",
+          "alt": "helix-logo"
+        }
+      ],
+      "data": {
+        "types": [
+          "has-image"
+        ]
+      }
+    }
+  ]
+}

--- a/test/fixtures/sections/headerpara2images.json
+++ b/test/fixtures/sections/headerpara2images.json
@@ -1,19 +1,20 @@
 {
-  "types": [
-    "has-image",
-    "has-text",
-    "has-heading",
-    "nb-image-2",
-    "nb-text-1",
-    "nb-heading-1",
-    "is-image-text-heading",
-    "is-image-text",
-    "is-image"
-  ],
   "image": "./helix_logo.png",
   "intro": "This is a paragraph.",
   "title": "Header, a paragraph and one image",
-  "meta": {},
+  "meta": {
+    "types": [
+      "has-image",
+      "has-text",
+      "has-heading",
+      "nb-image-2",
+      "nb-text-1",
+      "nb-heading-1",
+      "is-image-text-heading",
+      "is-image-text",
+      "is-image"
+    ]
+  },
   "type": "root",
   "children": [
     {
@@ -25,7 +26,7 @@
           "value": "Header, a paragraph and one image"
         }
       ],
-      "data": {
+      "meta": {
         "types": [
           "is-heading"
         ]
@@ -39,7 +40,7 @@
           "value": "This is a paragraph."
         }
       ],
-      "data": {
+      "meta": {
         "types": [
           "is-text"
         ]
@@ -65,7 +66,7 @@
           "alt": "helix-logo"
         }
       ],
-      "data": {
+      "meta": {
         "types": [
           "has-image"
         ]

--- a/test/fixtures/sections/headerparagraph.json
+++ b/test/fixtures/sections/headerparagraph.json
@@ -1,47 +1,45 @@
-[
-  {
-    "types": [
-      "has-text",
-      "has-heading",
-      "nb-text-1",
-      "nb-heading-1",
-      "is-text-heading",
-      "is-text"
-    ],
-    "intro": "This is a paragraph.",
-    "title": "Header and one paragraph",
-    "meta": {},
-    "type": "root",
-    "children": [
-      {
-        "type": "heading",
-        "depth": 1,
-        "children": [
-          {
-            "type": "text",
-            "value": "Header and one paragraph"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-heading"
-          ]
+{
+  "types": [
+    "has-text",
+    "has-heading",
+    "nb-text-1",
+    "nb-heading-1",
+    "is-text-heading",
+    "is-text"
+  ],
+  "intro": "This is a paragraph.",
+  "title": "Header and one paragraph",
+  "meta": {},
+  "type": "root",
+  "children": [
+    {
+      "type": "heading",
+      "depth": 1,
+      "children": [
+        {
+          "type": "text",
+          "value": "Header and one paragraph"
         }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "This is a paragraph."
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text"
-          ]
-        }
+      ],
+      "data": {
+        "types": [
+          "is-heading"
+        ]
       }
-    ]
-  }
-]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "This is a paragraph."
+        }
+      ],
+      "data": {
+        "types": [
+          "is-text"
+        ]
+      }
+    }
+  ]
+}

--- a/test/fixtures/sections/headerparaimage.json
+++ b/test/fixtures/sections/headerparaimage.json
@@ -1,67 +1,65 @@
-[
-  {
-    "types": [
-      "has-image",
-      "has-text",
-      "has-heading",
-      "nb-image-1",
-      "nb-text-1",
-      "nb-heading-1",
-      "is-image-text-heading",
-      "is-image-text",
-      "is-image"
-    ],
-    "image": "./helix_logo.png",
-    "intro": "This is a paragraph.",
-    "title": "Header, a paragraph and one image",
-    "meta": {},
-    "type": "root",
-    "children": [
-      {
-        "type": "heading",
-        "depth": 1,
-        "children": [
-          {
-            "type": "text",
-            "value": "Header, a paragraph and one image"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-heading"
-          ]
+{
+  "types": [
+    "has-image",
+    "has-text",
+    "has-heading",
+    "nb-image-1",
+    "nb-text-1",
+    "nb-heading-1",
+    "is-image-text-heading",
+    "is-image-text",
+    "is-image"
+  ],
+  "image": "./helix_logo.png",
+  "intro": "This is a paragraph.",
+  "title": "Header, a paragraph and one image",
+  "meta": {},
+  "type": "root",
+  "children": [
+    {
+      "type": "heading",
+      "depth": 1,
+      "children": [
+        {
+          "type": "text",
+          "value": "Header, a paragraph and one image"
         }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "This is a paragraph."
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text"
-          ]
-        }
-      },
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "image",
-            "title": null,
-            "url": "./helix_logo.png",
-            "alt": "helix-logo"
-          }
-        ],
-        "data": {
-          "types": [
-            "has-image"
-          ]
-        }
+      ],
+      "data": {
+        "types": [
+          "is-heading"
+        ]
       }
-    ]
-  }
-]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "This is a paragraph."
+        }
+      ],
+      "data": {
+        "types": [
+          "is-text"
+        ]
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "image",
+          "title": null,
+          "url": "./helix_logo.png",
+          "alt": "helix-logo"
+        }
+      ],
+      "data": {
+        "types": [
+          "has-image"
+        ]
+      }
+    }
+  ]
+}

--- a/test/fixtures/sections/paragraph.json
+++ b/test/fixtures/sections/paragraph.json
@@ -1,29 +1,27 @@
-[
-  {
-    "title": "This is only a paragraph.",
-    "types": [
-      "has-text",
-      "nb-text-1",
-      "has-only-text"
-    ],
-    "intro": "This is only a paragraph.",
-    "meta": {},
-    "type": "root",
-    "children": [
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "This is only a paragraph."
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text"
-          ]
+{
+  "title": "This is only a paragraph.",
+  "types": [
+    "has-text",
+    "nb-text-1",
+    "has-only-text"
+  ],
+  "intro": "This is only a paragraph.",
+  "meta": {},
+  "type": "root",
+  "children": [
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "This is only a paragraph."
         }
+      ],
+      "data": {
+        "types": [
+          "is-text"
+        ]
       }
-    ]
-  }
-]
+    }
+  ]
+}

--- a/test/fixtures/sections/paragraphwithlink.json
+++ b/test/fixtures/sections/paragraphwithlink.json
@@ -1,48 +1,46 @@
-[
-  {
-    "title": "This is a paragraph with a link!",
-    "types": [
-      "has-text",
-      "has-link",
-      "nb-text-2",
-      "nb-link-1",
-      "is-text-link",
-      "is-text"
-    ],
-    "intro": "This is a paragraph with a link!",
-    "meta": {},
-    "type": "root",
-    "children": [
-      {
-        "type": "paragraph",
-        "children": [
-          {
-            "type": "text",
-            "value": "This is a paragraph with a "
-          },
-          {
-            "type": "link",
-            "title": null,
-            "url": "/index.html",
-            "children": [
-              {
-                "type": "text",
-                "value": "link"
-              }
-            ]
-          },
-          {
-            "type": "text",
-            "value": "!"
-          }
-        ],
-        "data": {
-          "types": [
-            "is-text",
-            "has-link"
+{
+  "title": "This is a paragraph with a link!",
+  "types": [
+    "has-text",
+    "has-link",
+    "nb-text-2",
+    "nb-link-1",
+    "is-text-link",
+    "is-text"
+  ],
+  "intro": "This is a paragraph with a link!",
+  "meta": {},
+  "type": "root",
+  "children": [
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "This is a paragraph with a "
+        },
+        {
+          "type": "link",
+          "title": null,
+          "url": "/index.html",
+          "children": [
+            {
+              "type": "text",
+              "value": "link"
+            }
           ]
+        },
+        {
+          "type": "text",
+          "value": "!"
         }
+      ],
+      "data": {
+        "types": [
+          "is-text",
+          "has-link"
+        ]
       }
-    ]
-  }
-]
+    }
+  ]
+}

--- a/test/testConditionalSections.js
+++ b/test/testConditionalSections.js
@@ -83,8 +83,8 @@ describe('Integration Test Section Strain Filtering', () => {
         // this is the main function (normally it would be the template function)
         // but we use it to assert that pre-processing has happened
         const { content } = context;
-        logger.debug(`Found ${content.sections.filter(nonhidden).length} nonhidden sections`);
-        assert.equal(content.sections.filter(nonhidden).length, 3);
+        logger.debug(`Found ${content.mdast.children.filter(nonhidden).length} nonhidden sections`);
+        assert.equal(content.mdast.children.filter(nonhidden).length, 3);
         setdefault(context, 'response', {}).body = content.document.body.innerHTML;
       },
       {
@@ -130,7 +130,9 @@ describe('Unit Test Section Strain Filtering', () => {
     const context = {
       request: crequest,
       content: {
-        sections: [],
+        mdast: {
+          children: [],
+        },
       },
     };
     const action = {
@@ -147,11 +149,13 @@ describe('Unit Test Section Strain Filtering', () => {
   it('Filters sections based on strain', () => {
     const context = {
       content: {
-        sections: [
-          { meta: { strain: 'test' } },
-          { meta: { strain: 'test' } },
-          { meta: { strain: 'no-test' } },
-        ],
+        mdast: {
+          children: [
+            { meta: { strain: 'test' } },
+            { meta: { strain: 'test' } },
+            { meta: { strain: 'no-test' } },
+          ],
+        },
       },
     };
     const action = {
@@ -163,17 +167,19 @@ describe('Unit Test Section Strain Filtering', () => {
       logger,
     };
     selectstrain(context, action);
-    assert.equal(context.content.sections.filter(nonhidden).length, 2);
+    assert.equal(context.content.mdast.children.filter(nonhidden).length, 2);
   });
 
   it('Filters sections based on strain (array)', () => {
     const context = {
       content: {
-        sections: [
-          { meta: { strain: 'test' } },
-          { meta: { strain: ['test', 'no-test'] } },
-          { meta: { strain: 'no-test' } },
-        ],
+        mdast: {
+          children: [
+            { meta: { strain: 'test' } },
+            { meta: { strain: ['test', 'no-test'] } },
+            { meta: { strain: 'no-test' } },
+          ],
+        },
       },
     };
     const action = {
@@ -185,17 +191,19 @@ describe('Unit Test Section Strain Filtering', () => {
       logger,
     };
     selectstrain(context, action);
-    assert.equal(context.content.sections.filter(nonhidden).length, 2);
+    assert.equal(context.content.mdast.children.filter(nonhidden).length, 2);
   });
 
   it('Keeps sections without a strain', () => {
     const context = {
       content: {
-        sections: [
-          { meta: { strain: 'test' } },
-          { meta: { strain: ['test', 'no-test'] } },
-          { meta: {} },
-        ],
+        mdast: {
+          children: [
+            { meta: { strain: 'test' } },
+            { meta: { strain: ['test', 'no-test'] } },
+            { meta: {} },
+          ],
+        },
       },
     };
     const action = {
@@ -207,17 +215,19 @@ describe('Unit Test Section Strain Filtering', () => {
       logger,
     };
     selectstrain(context, action);
-    assert.equal(context.content.sections.filter(nonhidden).length, 2);
+    assert.equal(context.content.mdast.children.filter(nonhidden).length, 2);
   });
 
   it('Keeps sections without metadata', () => {
     const context = {
       content: {
-        sections: [
-          { meta: { strain: 'test' } },
-          { meta: { strain: ['test', 'no-test'] } },
-          {},
-        ],
+        mdast: {
+          children: [
+            { meta: { strain: 'test' } },
+            { meta: { strain: ['test', 'no-test'] } },
+            {},
+          ],
+        },
       },
     };
     const action = {
@@ -229,45 +239,47 @@ describe('Unit Test Section Strain Filtering', () => {
       logger,
     };
     selectstrain(context, action);
-    assert.equal(context.content.sections.filter(nonhidden).length, 2);
+    assert.equal(context.content.mdast.children.filter(nonhidden).length, 2);
   });
 
 
   it('Filters strain a', () => {
     const context = {
       content: {
-        sections: [{
-          type: 'root',
-          children: [],
-          title: 'This is an easy test.',
-          types: ['has-paragraph', 'has-only-paragraph'],
-          intro: 'This is an easy test.',
-          meta: { frontmatter: true },
+        mdast: {
+          children: [{
+            type: 'root',
+            children: [],
+            title: 'This is an easy test.',
+            types: ['has-paragraph', 'has-only-paragraph'],
+            intro: 'This is an easy test.',
+            meta: { frontmatter: true },
+          },
+          {
+            type: 'root',
+            children: [],
+            title: 'These two sections should always be shown',
+            types: ['has-paragraph', 'has-only-paragraph'],
+            intro: 'These two sections should always be shown',
+            meta: {},
+          },
+          {
+            type: 'root',
+            children: [],
+            title: 'But this one only in strain “A”',
+            types: ['has-paragraph', 'has-only-paragraph'],
+            intro: 'But this one only in strain “A”',
+            meta: { strain: 'a' },
+          },
+          {
+            type: 'root',
+            children: [],
+            title: 'And this one only in strain “B”',
+            types: ['has-paragraph', 'has-only-paragraph'],
+            intro: 'And this one only in strain “B”',
+            meta: { strain: 'b' },
+          }],
         },
-        {
-          type: 'root',
-          children: [],
-          title: 'These two sections should always be shown',
-          types: ['has-paragraph', 'has-only-paragraph'],
-          intro: 'These two sections should always be shown',
-          meta: {},
-        },
-        {
-          type: 'root',
-          children: [],
-          title: 'But this one only in strain “A”',
-          types: ['has-paragraph', 'has-only-paragraph'],
-          intro: 'But this one only in strain “A”',
-          meta: { strain: 'a' },
-        },
-        {
-          type: 'root',
-          children: [],
-          title: 'And this one only in strain “B”',
-          types: ['has-paragraph', 'has-only-paragraph'],
-          intro: 'And this one only in strain “B”',
-          meta: { strain: 'b' },
-        }],
       },
     };
     const action = {
@@ -279,8 +291,8 @@ describe('Unit Test Section Strain Filtering', () => {
       logger,
     };
     selectstrain(context, action);
-    assert.equal(context.content.sections.filter(nonhidden).length, 3);
-    assert.equal(context.content.sections.filter(nonhidden)[0].meta.hidden, false);
+    assert.equal(context.content.mdast.children.filter(nonhidden).length, 3);
+    assert.equal(context.content.mdast.children.filter(nonhidden)[0].meta.hidden, false);
   });
 });
 
@@ -339,9 +351,9 @@ describe('Integration Test A/B Testing', () => {
         const { content } = context;
         // this is the main function (normally it would be the template function)
         // but we use it to assert that pre-processing has happened
-        logger.debug(`Found ${content.sections.filter(nonhidden).length} nonhidden sections`);
-        assert.equal(content.sections.filter(nonhidden).length, 3);
-        assert.equal(content.sections.filter(nonhidden)[2].meta.test, 'a');
+        logger.debug(`Found ${content.mdast.children.filter(nonhidden).length} nonhidden sections`);
+        assert.equal(content.mdast.children.filter(nonhidden).length, 3);
+        assert.equal(content.mdast.children.filter(nonhidden)[2].meta.test, 'a');
         setdefault(context, 'response', {}).body = content.document.body.innerHTML;
       },
       {
@@ -390,11 +402,11 @@ Or this one at the same time.
           const { content } = context;
           // this is the main function (normally it would be the template function)
           // but we use it to assert that pre-processing has happened
-          logger.debug(`Found ${content.sections.filter(nonhidden).length} nonhidden sections`);
-          assert.equal(content.sections.filter(nonhidden).length, 3);
+          logger.debug(`Found ${content.mdast.children.filter(nonhidden).length} nonhidden sections`);
+          assert.equal(content.mdast.children.filter(nonhidden).length, 3);
           // remember what was selected
           /* eslint-disable-next-line prefer-destructuring */
-          selected = content.sections.filter(nonhidden)[2];
+          selected = content.mdast.children.filter(nonhidden)[2];
           setdefault(context, 'response', {}).body = content.document.body.innerHTML;
         },
         {
@@ -441,7 +453,7 @@ Or that one at the same time, because they are both part of an A/B test.
     // format, section metadata, the mdast format or the input above, you probably
     // want to change one of these values until you find one that *happens* to work
     // again...
-    assert.notDeepEqual(await runpipe('foo'), await runpipe('bang'));
+    assert.notDeepEqual(await runpipe('foo'), await runpipe('bar'));
     assert.deepEqual(await runpipe('baz'), await runpipe('baz'));
   });
 });

--- a/test/testConditionalSections.js
+++ b/test/testConditionalSections.js
@@ -453,7 +453,7 @@ Or that one at the same time, because they are both part of an A/B test.
     // format, section metadata, the mdast format or the input above, you probably
     // want to change one of these values until you find one that *happens* to work
     // again...
-    assert.notDeepEqual(await runpipe('foo'), await runpipe('bar'));
+    assert.notDeepEqual(await runpipe('foo'), await runpipe('qux'));
     assert.deepEqual(await runpipe('baz'), await runpipe('baz'));
   });
 });

--- a/test/testGetMetadata.js
+++ b/test/testGetMetadata.js
@@ -59,7 +59,7 @@ describe('Test getMetadata', () => {
       },
     };
     getmetadata(dat, { logger });
-    assert.deepEqual(dat.content.meta, {});
+    assert.deepEqual(dat.content.meta, { types: [] });
   });
 
   it('getmetadata does not fail with empty sections', () => {
@@ -74,18 +74,21 @@ describe('Test getMetadata', () => {
     };
     getmetadata(dat, { logger });
     assert.deepEqual(dat.content, {
-      meta: {},
+      meta: {
+        types: [],
+      },
       title: '',
       intro: '',
       image: undefined,
       mdast: {
         children: [],
         position: {},
-        meta: {},
+        meta: {
+          types: [],
+        },
         type: '',
         title: '',
         intro: '',
-        types: [],
       },
     });
   });

--- a/test/testGetMetadata.js
+++ b/test/testGetMetadata.js
@@ -29,7 +29,7 @@ function callback(body) {
   parseFront(dat);
   split(dat, { logger });
   getmetadata(dat, { logger });
-  return dat.content.sections;
+  return dat.content.mdast;
 }
 
 const SECTIONS_BLOCS = [
@@ -55,26 +55,7 @@ describe('Test getMetadata', () => {
   it('getmetadata does not fail with "empty" mdast', () => {
     const dat = {
       content: {
-        sections: [],
-        mdast: {
-          children: [],
-          position: {},
-          type: '',
-        },
-      },
-    };
-    getmetadata(dat, { logger });
-    assert.deepEqual(dat.content.meta, {});
-  });
-
-  it('getmetadata does not fail with missing sections', () => {
-    const dat = {
-      content: {
-        mdast: {
-          children: [],
-          position: {},
-          type: '',
-        },
+        mdast: {},
       },
     };
     getmetadata(dat, { logger });
@@ -84,7 +65,6 @@ describe('Test getMetadata', () => {
   it('getmetadata does not fail with empty sections', () => {
     const dat = {
       content: {
-        sections: [{}],
         mdast: {
           children: [],
           position: {},
@@ -94,12 +74,6 @@ describe('Test getMetadata', () => {
     };
     getmetadata(dat, { logger });
     assert.deepEqual(dat.content, {
-      sections: [{
-        meta: {},
-        title: '',
-        intro: '',
-        types: [],
-      }],
       meta: {},
       title: '',
       intro: '',
@@ -107,7 +81,11 @@ describe('Test getMetadata', () => {
       mdast: {
         children: [],
         position: {},
+        meta: {},
         type: '',
+        title: '',
+        intro: '',
+        types: [],
       },
     });
   });

--- a/test/testHTML.js
+++ b/test/testHTML.js
@@ -465,7 +465,9 @@ ${context.content.document.body.innerHTML}`,
       {
         request: crequest,
         content: {
-          sections: [{ type: 'notroot' }],
+          mdast: {
+            type: 'notroot',
+          },
         },
       },
       {
@@ -476,7 +478,7 @@ ${context.content.document.body.innerHTML}`,
     );
     assert.ok(result.error);
     assert(result.error.stack.includes('Error: Invalid Context'));
-    assert(result.error.stack.includes('should be equal to constant'));
+    assert(result.error.stack.includes('should be equal to one of the allowed values'));
   });
 
   it('html.pipe complains with a specific message for mdast nodes wih extra properties when context is invalid', async () => {
@@ -486,7 +488,9 @@ ${context.content.document.body.innerHTML}`,
       }, {
         request: crequest,
         content: {
-          sections: [{ type: 'root', custom: 'notallowed' }],
+          mdast: {
+            children: [{ type: 'root', custom: 'notallowed' }],
+          },
         },
       },
       {

--- a/test/testHTMLFromMarkdown.js
+++ b/test/testHTMLFromMarkdown.js
@@ -392,7 +392,7 @@ describe('Testing Markdown conversion', () => {
   it('Exposes section meta data', async () => {
     await assertMd(`
         ---
-        foo: bar
+        title: foo
         ---
 
         # Foo
@@ -405,40 +405,61 @@ describe('Testing Markdown conversion', () => {
         # Baz
 
         ---
-        corge: grault
         tagname: section
         ---
 
         # Corge
 
         ---
-        garply: waldo
-        meta: true
+        data-meta: true
         ---
 
         # Garply
 
         ---
-        fred: plugh
-        types: true
+        data-hlx-types: [fred, plugh]
         ---
 
         # Fred
       `, `
-        <div class="hlx-section">
+        <div class="hlx-section" title="foo" data-hlx-types="has-heading nb-heading-1 has-only-heading">
           <h1 id="foo">Foo</h1>
         </div>
-        <div class="qux-section">
+        <div class="hlx-section qux-section" data-baz="qux" data-hlx-types="has-heading nb-heading-1 has-only-heading">
           <h1 id="baz">Baz</h1>
         </div>
-        <section class="hlx-section">
+        <section class="hlx-section" data-hlx-types="has-heading nb-heading-1 has-only-heading">
           <h1 id="corge">Corge</h1>
         </section>
-        <div class="hlx-section" data-hlx-garply="waldo">
+        <div class="hlx-section" data-meta data-hlx-types="has-heading nb-heading-1 has-only-heading">
           <h1 id="garply">Garply</h1>
         </div>
-        <div class="hlx-section has-heading nb-heading-1 has-only-heading">
+        <div class="hlx-section" data-hlx-types="fred plugh">
           <h1 id="fred">Fred</h1>
+        </div>
+    `, {
+      SANITIZE_DOM: true,
+    });
+  });
+
+  it('Filters out hlx-* class and data-hlx-* attributes in production', async () => {
+    process.env.__OW_ACTIVATION_ID = '1234';
+    await assertMd(`
+        ---
+
+        # Foo
+
+        ---
+        data-hlx-types: [bar, baz]
+        ---
+
+        # Bar
+      `, `
+        <div>
+          <h1 id="foo">Foo</h1>
+        </div>
+        <div>
+          <h1 id="bar">Bar</h1>
         </div>
     `, {
       SANITIZE_DOM: true,

--- a/test/testHTMLFromMarkdown.js
+++ b/test/testHTMLFromMarkdown.js
@@ -388,4 +388,60 @@ describe('Testing Markdown conversion', () => {
       SANITIZE_DOM: true,
     });
   });
+
+  it('Exposes section meta data', async () => {
+    await assertMd(`
+        ---
+        foo: bar
+        ---
+
+        # Foo
+
+        ---
+        baz: qux
+        class: qux-section
+        ---
+
+        # Baz
+
+        ---
+        corge: grault
+        tagname: section
+        ---
+
+        # Corge
+
+        ---
+        garply: waldo
+        meta: true
+        ---
+
+        # Garply
+
+        ---
+        fred: plugh
+        types: true
+        ---
+
+        # Fred
+      `, `
+        <div class="hlx-section">
+          <h1 id="foo">Foo</h1>
+        </div>
+        <div class="qux-section">
+          <h1 id="baz">Baz</h1>
+        </div>
+        <section class="hlx-section">
+          <h1 id="corge">Corge</h1>
+        </section>
+        <div class="hlx-section" data-hlx-garply="waldo">
+          <h1 id="garply">Garply</h1>
+        </div>
+        <div class="hlx-section has-heading nb-heading-1 has-only-heading">
+          <h1 id="fred">Fred</h1>
+        </div>
+    `, {
+      SANITIZE_DOM: true,
+    });
+  });
 });

--- a/test/testSplitSections.js
+++ b/test/testSplitSections.js
@@ -26,7 +26,7 @@ function callback(body) {
   parse(data, { logger });
   parseFront(data);
   split(data, { logger });
-  return data.content.sections;
+  return data.content.mdast.children;
 }
 
 describe('Test Section Splitting', () => {


### PR DESCRIPTION
Include proper sections in the HTML pipeline instead of plain `<hr>` sectioning

BREAKING CHANGE:
- Remove `context.content.sections` and move the sections directly under
`context.content.mdast`
- Adjust json schemas accordingly
- Move the section yaml meta info to `<node>.meta`
- Move the section types to the mdast `<node>.meta.types`

Is dependent on adobe/helix-cli#1037

fix #279