### PR TITLE
feat(fetch): resolve github ref to commit sha

### DIFF
--- a/docs/secrets.schema.json
+++ b/docs/secrets.schema.json
@@ -78,6 +78,11 @@
             "type": "boolean",
             "description": "Sanitize the HTML output to guard against XSS attacks. \n\n**Note:** this flag applies a pretty aggressive DOM filtering that will strip out a lot of HTML that your authors might find useful. The setting is meant for processing truly untrusted inputs, such as comments in a social media site.",
             "default": false
+        },
+        "RESOLVE_GITREF_SERVICE": {
+            "type": "string",
+            "description": "API endpoint or action name to the service that resolves github refs to commit SHAs.",
+            "default": ""
         }
     }
 }

--- a/docs/secrets.schema.md
+++ b/docs/secrets.schema.md
@@ -22,6 +22,7 @@ Secrets passed into the pipeline such as API Keys or configuration settings.
 | [IMAGES_MIN_SIZE](#images_min_size) | `integer` | Optional  | No | `480` | Secrets (this schema) |
 | [REPO_API_ROOT](#repo_api_root) | `string` | Optional  | No | `"https://api.github.com/"` | Secrets (this schema) |
 | [REPO_RAW_ROOT](#repo_raw_root) | `string` | Optional  | No | `"https://raw.githubusercontent.com/"` | Secrets (this schema) |
+| [RESOLVE_GITREF_SERVICE](#resolve_gitref_service) | `string` | Optional  | No | `""` | Secrets (this schema) |
 | [SANITIZE_DOM](#sanitize_dom) | `boolean` | Optional  | No | `false` | Secrets (this schema) |
 | [TEST_BOOLEAN](#test_boolean) | `boolean` | Optional  | No | `true` | Secrets (this schema) |
 | [XML_PRETTY](#xml_pretty) | `boolean` | Optional  | No | `true` | Secrets (this schema) |
@@ -177,6 +178,28 @@ The Base URL for retrieving raw text files from GitHub
 `string`
 
 * format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
+
+
+
+
+
+
+## RESOLVE_GITREF_SERVICE
+
+API endpoint or action name to the service that resolves github refs to commit SHAs.
+
+`RESOLVE_GITREF_SERVICE`
+
+* is optional
+* type: `string`
+* default: `""`
+* defined in this schema
+
+### RESOLVE_GITREF_SERVICE Type
+
+
+`string`
+
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1132,7 +1132,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
       "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
-      "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -1392,8 +1391,7 @@
     "ast-types": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.1.tgz",
-      "integrity": "sha512-b+EeK0WlzrSmpMw5jktWvQGxblpWnvMrV+vOp69RLjzGiHwWV0vgq75DPKtUjppKni3yWwSW8WLGV3Ch/XIWcQ==",
-      "dev": true
+      "integrity": "sha512-b+EeK0WlzrSmpMw5jktWvQGxblpWnvMrV+vOp69RLjzGiHwWV0vgq75DPKtUjppKni3yWwSW8WLGV3Ch/XIWcQ=="
     },
     "ast-types-flow": {
       "version": "0.0.7",
@@ -1871,8 +1869,7 @@
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-      "dev": true
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "cache-base": {
       "version": "1.0.1",
@@ -2840,7 +2837,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.1.tgz",
       "integrity": "sha512-OkVVLrerfAKZlW2ZZ3Ve2y65jgiWqBKsTfUIAFbn8nVbPcCZg6l6gikKlEYv0kXcmzqGm6mFq/Jf2vriuEkv8A==",
-      "dev": true,
       "requires": {
         "@types/node": "^8.0.7"
       },
@@ -2848,8 +2844,7 @@
         "@types/node": {
           "version": "8.10.48",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.48.tgz",
-          "integrity": "sha512-c35YEBTkL4rzXY2ucpSKy+UYHjUBIIkuJbWYbsGIrKLEWU5dgJMmLkkIb3qeC3O3Tpb1ZQCwecscvJTDjDjkRw==",
-          "dev": true
+          "integrity": "sha512-c35YEBTkL4rzXY2ucpSKy+UYHjUBIIkuJbWYbsGIrKLEWU5dgJMmLkkIb3qeC3O3Tpb1ZQCwecscvJTDjDjkRw=="
         }
       }
     },
@@ -3031,7 +3026,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
       "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
-      "dev": true,
       "requires": {
         "ast-types": "0.x.x",
         "escodegen": "1.x.x",
@@ -3041,8 +3035,7 @@
         "esprima": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
         }
       }
     },
@@ -3077,8 +3070,7 @@
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-      "dev": true
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "destroy": {
       "version": "1.0.4",
@@ -3382,14 +3374,12 @@
     "es6-promise": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
-      "dev": true
+      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
     },
     "es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dev": true,
       "requires": {
         "es6-promise": "^4.0.3"
       }
@@ -4267,8 +4257,7 @@
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "fileset": {
       "version": "2.0.3",
@@ -4774,7 +4763,6 @@
       "version": "0.3.10",
       "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
       "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
-      "dev": true,
       "requires": {
         "readable-stream": "1.1.x",
         "xregexp": "2.0.0"
@@ -4784,7 +4772,6 @@
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -4845,7 +4832,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.3.tgz",
       "integrity": "sha512-x5j6Ks7FOgLD/GlvjKwgu7wdmMR55iuRHhn8hj/+gA+eSbxQvZ+AEomq+3MgVEZj1vpi738QahGbCCSIDtXtkw==",
-      "dev": true,
       "requires": {
         "data-uri-to-buffer": "2",
         "debug": "4",
@@ -4859,7 +4845,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -4868,7 +4853,6 @@
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
           "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
-          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -4879,7 +4863,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
           "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -5321,7 +5304,6 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-      "dev": true,
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -5353,7 +5335,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
       "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-      "dev": true,
       "requires": {
         "agent-base": "4",
         "debug": "3.1.0"
@@ -5363,7 +5344,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -5371,8 +5351,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -5390,7 +5369,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
-      "dev": true,
       "requires": {
         "agent-base": "^4.1.0",
         "debug": "^3.1.0"
@@ -5623,8 +5601,7 @@
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-      "dev": true
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ipaddr.js": {
       "version": "1.8.0",
@@ -5972,8 +5949,7 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "dev": true
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isexe": {
       "version": "2.0.0",
@@ -7005,7 +6981,6 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dev": true,
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -7813,7 +7788,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
       "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
-      "dev": true,
       "requires": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -7824,7 +7798,6 @@
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -7858,8 +7831,7 @@
     "netmask": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
-      "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
-      "dev": true
+      "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
     },
     "next-tick": {
       "version": "1.0.0",
@@ -12059,6 +12031,15 @@
         "format-util": "^1.0.3"
       }
     },
+    "openwhisk": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/openwhisk/-/openwhisk-3.19.0.tgz",
+      "integrity": "sha512-xfo0YiYhssW7AGX9p8sDCYXfl2iyVoZS7K2PpXtrnhBBWrd765goxEvxr1cwqcu8LpMUy0EDHhPHT3SFUdsoOQ==",
+      "requires": {
+        "needle": "^2.1.0",
+        "proxy-agent": "^3.0.3"
+      }
+    },
     "opn": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
@@ -12244,7 +12225,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-3.0.0.tgz",
       "integrity": "sha512-AOUX9jES/EkQX2zRz0AW7lSx9jD//hQS8wFXBvcnd/J2Py9KaMJMqV/LPqJssj1tgGufotb2mmopGPR15ODv1Q==",
-      "dev": true,
       "requires": {
         "agent-base": "^4.2.0",
         "debug": "^3.1.0",
@@ -12260,7 +12240,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-3.0.0.tgz",
       "integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
-      "dev": true,
       "requires": {
         "co": "^4.6.0",
         "degenerator": "^1.0.4",
@@ -12653,7 +12632,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-3.1.0.tgz",
       "integrity": "sha512-IkbZL4ClW3wwBL/ABFD2zJ8iP84CY0uKMvBPk/OceQe/cEjrxzN1pMHsLwhbzUoRhG9QbSxYC+Z7LBkTiBNvrA==",
-      "dev": true,
       "requires": {
         "agent-base": "^4.2.0",
         "debug": "^3.1.0",
@@ -12668,14 +12646,12 @@
     "proxy-from-env": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
-      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
-      "dev": true
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
     },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
       "version": "1.1.29",
@@ -12729,7 +12705,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
       "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
-      "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "http-errors": "1.6.3",
@@ -12741,7 +12716,6 @@
           "version": "0.4.23",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-          "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -13663,8 +13637,7 @@
     "setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-      "dev": true
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "shallow-clone": {
       "version": "0.1.2",
@@ -13784,8 +13757,7 @@
     "smart-buffer": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
-      "integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==",
-      "dev": true
+      "integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw=="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -14253,7 +14225,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.2.tgz",
       "integrity": "sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==",
-      "dev": true,
       "requires": {
         "ip": "^1.1.5",
         "smart-buffer": "4.0.2"
@@ -14263,7 +14234,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
       "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
-      "dev": true,
       "requires": {
         "agent-base": "~4.2.1",
         "socks": "~2.3.2"
@@ -14455,8 +14425,7 @@
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-      "dev": true
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stdin": {
       "version": "0.0.1",
@@ -14498,8 +14467,7 @@
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringify-object": {
       "version": "3.3.0",
@@ -14843,8 +14811,7 @@
     "thunkify": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
-      "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0=",
-      "dev": true
+      "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0="
     },
     "timed-out": {
       "version": "4.0.1",
@@ -15283,8 +15250,7 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-      "dev": true
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unset-value": {
       "version": "1.0.0",
@@ -15792,8 +15758,7 @@
     "xregexp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
-      "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=",
-      "dev": true
+      "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
     },
     "xtend": {
       "version": "4.0.1",
@@ -15809,8 +15774,7 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yaml": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "mdurl": "^1.0.1",
     "micromatch": "^4.0.0",
     "object-hash": "^1.3.1",
+    "openwhisk": "^3.19.0",
     "property-information": "^5.1.0",
     "remark-parse": "^6.0.0",
     "request": "^2.87.0",

--- a/src/action.d.ts
+++ b/src/action.d.ts
@@ -144,6 +144,10 @@ export interface Secrets {
    */
   SANITIZE_DOM?: boolean;
   /**
+   * API endpoint or action name to the service that resolves github refs to commit SHAs.
+   */
+  RESOLVE_GITREF_SERVICE?: string;
+  /**
    * This interface was referenced by `Secrets`'s JSON-Schema definition
    * via the `patternProperty` "[A-Z0-9_]+".
    */

--- a/src/defaults/html.pipe.js
+++ b/src/defaults/html.pipe.js
@@ -37,6 +37,7 @@ const tohtml = require('../html/stringify-response');
 const addHeaders = require('../html/add-headers');
 const timing = require('../utils/timing');
 const sanitize = require('../html/sanitize');
+const resolveRef = require('../utils/resolve-ref');
 
 /* eslint newline-per-chained-call: off */
 
@@ -57,6 +58,7 @@ const htmlpipe = (cont, context, action) => {
     .every(dump.record)
     .every(validate).when(() => !production())
     .every(timer.update)
+    .before(resolveRef).expose('resolve').when(hascontent)
     .before(fetch).expose('fetch').when(hascontent)
     .before(parse).expose('parse')
     .before(parseFrontmatter)

--- a/src/schemas/secrets.schema.json
+++ b/src/schemas/secrets.schema.json
@@ -73,6 +73,11 @@
       "type":"boolean",
       "description": "Sanitize the HTML output to guard against XSS attacks. \n\n**Note:** this flag applies a pretty aggressive DOM filtering that will strip out a lot of HTML that your authors might find useful. The setting is meant for processing truly untrusted inputs, such as comments in a social media site.",
       "default":false
+    },
+    "RESOLVE_GITREF_SERVICE": {
+      "type": "string",
+      "description": "API endpoint or action name to the service that resolves github refs to commit SHAs.",
+      "default": ""
     }
   }
 }

--- a/src/utils/resolve-ref.js
+++ b/src/utils/resolve-ref.js
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+const rp = require('request-promise-native');
+const URI = require('uri-js');
+const openwhisk = require('openwhisk');
+
+const REGEXP_SHA = /^[0-9a-f]{40}$/i;
+
+/**
+ * Calls the lookup service either by invoking the action directly or fetching the result via
+ * http request.
+ *
+ * @param {string} urlOrName - The service url or action name.
+ * @param {object} params - the action params.
+ * @returns {object} The result object.
+ */
+async function callService(urlOrName, params) {
+  if (!urlOrName.startsWith('https://')) {
+    // assume openwhisk action
+    if (!process.env.__OW_API_KEY) {
+      throw Error('cannot invoke action outside openwhisk environment.');
+    }
+    const ow = openwhisk();
+    const res = await ow.actions.invoke({
+      name: urlOrName,
+      blocking: true,
+      result: true,
+      params,
+    });
+    return res.body;
+  }
+  const result = await rp({
+    url: urlOrName,
+    qs: params,
+    json: true,
+  });
+  if (result.status === 'error') {
+    throw Error(result.statusMessage);
+  }
+  return result;
+}
+
+/**
+ * Resolves the 'ref' of a github request if it's not already a SHA.
+ * The function uses the resolve-git-ref service API which needs to be provided via the
+ * {@code secrets.API_RESOLVE_GIT_REF} parameter. If the 'ref' looks already like a commit SHA,
+ * the lookup is ignored.
+ * After a successful lookup the {@code action.request.params.ref} is replaced with the SHA.
+ *
+ * @see https://github.com/adobe/helix-resolve-git-ref
+ */
+async function resolveRef(context, { secrets = {}, request, logger }) {
+  if (!request || !request.params) {
+    throw new Error('Request parameters missing');
+  }
+  if (!secrets.REPO_RAW_ROOT) {
+    logger.debug('cannot resolve ref. No REPO_RAW_ROOT specified.');
+    return;
+  }
+  const rootURI = URI.parse(secrets.REPO_RAW_ROOT);
+  if (rootURI.host !== 'raw.github.com' && rootURI.host !== 'raw.githubusercontent.com') {
+    logger.warn(`unable to resolve ref to non-github repository: ${secrets.REPO_RAW_ROOT}`);
+    return;
+  }
+
+  const lookupUrl = secrets.RESOLVE_GITREF_SERVICE;
+  if (!lookupUrl) {
+    logger.debug('ignoring github ref resolving. RESOLVE_GITREF_SERVICE is not set.');
+    return;
+  }
+
+  // get required request parameters
+  const {
+    owner, repo,
+  } = request.params;
+
+  let { ref } = request.params;
+  if (!owner) {
+    throw new Error('Unknown owner, cannot resolve github ref');
+  }
+  if (!repo) {
+    throw new Error('Unknown repo, cannot resolve github ref');
+  }
+  if (!ref) {
+    logger.warn(`Recoverable error: no ref given for ${repo}/${owner}, falling back to master`);
+    ref = 'master';
+  }
+
+  if (REGEXP_SHA.test(ref)) {
+    logger.debug(`github-ref '${ref}' looks like a SHA. Ignoring resolving.`);
+    return;
+  }
+
+  try {
+    const result = await callService(lookupUrl, {
+      owner,
+      repo,
+      ref,
+    });
+    logger.debug(`resolved github-ref '${ref}' to '${result.sha}'`);
+    request.params.ref = result.sha;
+  } catch (e) {
+    logger.debug(`unable to resolve github-ref of ${ref}: ${e.message}`);
+  }
+}
+
+module.exports = resolveRef;

--- a/test/fixtures/Test-resolve-git-ref_2496004244/Resolve-resolves-master-ref-correctly-_4084244876/recording.har
+++ b/test/fixtures/Test-resolve-git-ref_2496004244/Resolve-resolves-master-ref-correctly-_4084244876/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "Test resolve git ref/Resolve resolves master ref correctly.",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "2.4.0"
+    },
+    "entries": [
+      {
+        "_id": "e692ed123439cb70b9d9522faf6e1f35",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "adobeioruntime.net"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            }
+          ],
+          "headersSize": 186,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "owner",
+              "value": "adobe"
+            },
+            {
+              "name": "repo",
+              "value": "helix-cli"
+            },
+            {
+              "name": "ref",
+              "value": "master"
+            }
+          ],
+          "url": "https://adobeioruntime.net/api/v1/web/helix/helix-services/resolve-git-ref%40v1?owner=adobe&repo=helix-cli&ref=master"
+        },
+        "response": {
+          "bodySize": 87,
+          "content": {
+            "mimeType": "application/json",
+            "size": 87,
+            "text": "{\n  \"fqRef\": \"refs/heads/master\",\n  \"sha\": \"565cb704628a094edde7e7f87d662b89559adcf0\"\n}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "access-control-allow-headers",
+              "value": "Authorization, Origin, X-Requested-With, Content-Type, Accept, User-Agent"
+            },
+            {
+              "name": "access-control-allow-methods",
+              "value": "OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 21 Jun 2019 01:29:41 GMT"
+            },
+            {
+              "name": "perf-br-resp-out",
+              "value": "1561080581.133"
+            },
+            {
+              "name": "server",
+              "value": "api-gateway/1.9.3.1"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "deny"
+            },
+            {
+              "name": "x-gw-cache",
+              "value": "MISS"
+            },
+            {
+              "name": "x-openwhisk-activation-id",
+              "value": "9874a4b2a61242b7b4a4b2a61242b75b"
+            },
+            {
+              "name": "x-request-id",
+              "value": "rzX94JsbiEydDeiNrASRRgT5eFZS05Wh"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "content-length",
+              "value": "87"
+            },
+            {
+              "name": "connection",
+              "value": "Close"
+            }
+          ],
+          "headersSize": 602,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-06-21T01:29:40.390Z",
+        "time": 823,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 823
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/fixtures/Test-resolve-git-ref_2496004244/Resolve-resolves-master-ref-correctly-using-openwhisk-_275354344/recording.har
+++ b/test/fixtures/Test-resolve-git-ref_2496004244/Resolve-resolves-master-ref-correctly-using-openwhisk-_275354344/recording.har
@@ -1,0 +1,127 @@
+{
+  "log": {
+    "_recordingName": "Test resolve git ref/Resolve resolves master ref correctly using openwhisk.",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "2.4.0"
+    },
+    "entries": [
+      {
+        "_id": "4c41e3aaf5eaf00ed28af7f193f8d62e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 51,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "openwhisk-client-js"
+            },
+            {
+              "name": "content-length",
+              "value": 51
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "host",
+              "value": "adobeioruntime.net"
+            }
+          ],
+          "headersSize": 278,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"owner\":\"adobe\",\"repo\":\"helix-cli\",\"ref\":\"master\"}"
+          },
+          "queryString": [
+            {
+              "name": "blocking",
+              "value": "true"
+            }
+          ],
+          "url": "https://adobeioruntime.net/api/v1/namespaces/helix/actions/helix-services/resolve-git-ref%40v1?blocking=true"
+        },
+        "response": {
+          "bodySize": 691,
+          "content": {
+            "mimeType": "application/json",
+            "size": 691,
+            "text": "{\"activationId\":\"152da2393e424116ada2393e4261168c\",\"annotations\":[{\"key\":\"topmost\",\"value\":true},{\"key\":\"path\",\"value\":\"helix/helix-services/resolve-git-ref@v1\"},{\"key\":\"kind\",\"value\":\"sequence\"},{\"key\":\"limits\",\"value\":{\"concurrency\":200,\"logs\":10,\"memory\":256,\"timeout\":60000}}],\"duration\":108,\"end\":1561080581943,\"logs\":[\"b63c0bb84dcc40ccbc0bb84dcc40cc05\"],\"name\":\"resolve-git-ref@v1\",\"namespace\":\"tripod\",\"publish\":false,\"response\":{\"result\":{\"body\":{\"fqRef\":\"refs/heads/master\",\"sha\":\"565cb704628a094edde7e7f87d662b89559adcf0\"},\"headers\":{\"Content-Type\":\"application/json\"},\"statusCode\":200},\"status\":\"success\",\"success\":true},\"start\":1561080581794,\"subject\":\"tripod\",\"version\":\"0.0.4\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "access-control-allow-headers",
+              "value": "Authorization, Origin, X-Requested-With, Content-Type, Accept, User-Agent"
+            },
+            {
+              "name": "access-control-allow-methods",
+              "value": "GET, DELETE, POST, PUT, HEAD"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 21 Jun 2019 01:29:41 GMT"
+            },
+            {
+              "name": "server",
+              "value": "api-gateway/1.9.3.1"
+            },
+            {
+              "name": "x-openwhisk-activation-id",
+              "value": "152da2393e424116ada2393e4261168c"
+            },
+            {
+              "name": "x-request-id",
+              "value": "MMVdGYKURyJpgsw5LbvVgogqVV9pW0nY"
+            },
+            {
+              "name": "content-length",
+              "value": "691"
+            },
+            {
+              "name": "connection",
+              "value": "Close"
+            }
+          ],
+          "headersSize": 446,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-06-21T01:29:41.238Z",
+        "time": 782,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 782
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/fixtures/Test-resolve-git-ref_2496004244/Resolve-resolves-missing-ref-as-master-correctly-_3792802480/recording.har
+++ b/test/fixtures/Test-resolve-git-ref_2496004244/Resolve-resolves-missing-ref-as-master-correctly-_3792802480/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "Test resolve git ref/Resolve resolves missing ref as master correctly.",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "2.4.0"
+    },
+    "entries": [
+      {
+        "_id": "e692ed123439cb70b9d9522faf6e1f35",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "host",
+              "value": "adobeioruntime.net"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            }
+          ],
+          "headersSize": 186,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "owner",
+              "value": "adobe"
+            },
+            {
+              "name": "repo",
+              "value": "helix-cli"
+            },
+            {
+              "name": "ref",
+              "value": "master"
+            }
+          ],
+          "url": "https://adobeioruntime.net/api/v1/web/helix/helix-services/resolve-git-ref%40v1?owner=adobe&repo=helix-cli&ref=master"
+        },
+        "response": {
+          "bodySize": 87,
+          "content": {
+            "mimeType": "application/json",
+            "size": 87,
+            "text": "{\n  \"fqRef\": \"refs/heads/master\",\n  \"sha\": \"565cb704628a094edde7e7f87d662b89559adcf0\"\n}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "access-control-allow-headers",
+              "value": "Authorization, Origin, X-Requested-With, Content-Type, Accept, User-Agent"
+            },
+            {
+              "name": "access-control-allow-methods",
+              "value": "OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 21 Jun 2019 01:29:42 GMT"
+            },
+            {
+              "name": "perf-br-resp-out",
+              "value": "1561080582.631"
+            },
+            {
+              "name": "server",
+              "value": "api-gateway/1.9.3.1"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "deny"
+            },
+            {
+              "name": "x-gw-cache",
+              "value": "MISS"
+            },
+            {
+              "name": "x-openwhisk-activation-id",
+              "value": "017f505626014602bf505626013602e5"
+            },
+            {
+              "name": "x-request-id",
+              "value": "lo6QTIkOk18ZxbB5VAaZUabymcDEcexA"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "content-length",
+              "value": "87"
+            },
+            {
+              "name": "connection",
+              "value": "Close"
+            }
+          ],
+          "headersSize": 602,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2019-06-21T01:29:42.032Z",
+        "time": 675,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 675
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/testResolveRef.js
+++ b/test/testResolveRef.js
@@ -1,0 +1,337 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+const assert = require('assert');
+const { Logger } = require('@adobe/helix-shared');
+const NodeHttpAdapter = require('@pollyjs/adapter-node-http');
+const FSPersister = require('@pollyjs/persister-fs');
+const setupPolly = require('@pollyjs/core').setupMocha;
+const resolveRef = require('../src/utils/resolve-ref');
+
+const RESOLVE_GITREF_SERVICE = 'https://adobeioruntime.net/api/v1/web/helix/helix-services/resolve-git-ref%40v1';
+const SERVICE_ACTION = '/helix/helix-services/resolve-git-ref%40v1';
+
+// set this to an actual wsk token during recording.
+const WSK_TOKEN = 'dummy';
+
+describe('Test resolve git ref', () => {
+  setupPolly({
+    logging: false,
+    recordFailedRequests: true,
+    recordIfMissing: false,
+    adapters: [NodeHttpAdapter],
+    persister: FSPersister,
+    persisterOptions: {
+      fs: {
+        recordingsDir: 'test/fixtures',
+      },
+    },
+  });
+  beforeEach(async function beforeEach() {
+    this.polly.server.any().on('beforeResponse', (req) => {
+      // don't record the authorization header
+      req.removeHeaders(['authorization']);
+    });
+    this.polly.configure({
+      matchRequestsBy: {
+        headers: {
+          exclude: ['authorization'],
+        },
+      },
+    });
+  });
+
+  it('Resolve throws if no request', async () => {
+    try {
+      await resolveRef({}, {});
+      assert.fail('should fail.');
+    } catch (e) {
+      assert.equal(e.message, 'Request parameters missing');
+    }
+  });
+
+  it('Resolve throws if no owner', async () => {
+    try {
+      await resolveRef({}, {
+        secrets: {
+          REPO_RAW_ROOT: 'https://raw.github.com/',
+          RESOLVE_GITREF_SERVICE,
+        },
+        request: {
+          params: {},
+        },
+
+      });
+      assert.fail('should fail.');
+    } catch (e) {
+      assert.equal(e.message, 'Unknown owner, cannot resolve github ref');
+    }
+  });
+
+  it('Resolve throws if no repo', async () => {
+    try {
+      await resolveRef({}, {
+        secrets: {
+          REPO_RAW_ROOT: 'https://raw.github.com/',
+          RESOLVE_GITREF_SERVICE,
+        },
+        request: {
+          params: {
+            owner: 'adobe',
+          },
+        },
+
+      });
+      assert.fail('should fail.');
+    } catch (e) {
+      assert.equal(e.message, 'Unknown repo, cannot resolve github ref');
+    }
+  });
+
+  it('Resolve ignores if no REPO_RAW_ROOT.', async () => {
+    const logger = Logger.getTestLogger({
+      level: 'debug',
+    });
+    await resolveRef({}, {
+      secrets: {
+        RESOLVE_GITREF_SERVICE,
+      },
+      logger,
+      request: {
+        params: {},
+      },
+    });
+    const out = await logger.getOutput();
+    assert.ok(out.indexOf('cannot resolve ref. No REPO_RAW_ROOT specified.') > 0);
+  });
+
+  it('Resolve ignores if non github REPO_RAW_ROOT.', async () => {
+    const logger = Logger.getTestLogger({
+      level: 'debug',
+    });
+    await resolveRef({}, {
+      secrets: {
+        REPO_RAW_ROOT: 'https://localhost:1234/',
+        RESOLVE_GITREF_SERVICE,
+      },
+      logger,
+      request: {
+        params: {},
+      },
+    });
+    const out = await logger.getOutput();
+    assert.ok(out.indexOf('unable to resolve ref to non-github repository: https://localhost:1234/') > 0);
+  });
+
+  it('Resolve ignores if RESOLVE_GITREF_SERVICE is missing.', async () => {
+    const logger = Logger.getTestLogger({
+      level: 'debug',
+    });
+    await resolveRef({}, {
+      secrets: {
+        REPO_RAW_ROOT: 'https://raw.github.com/',
+      },
+      logger,
+      request: {
+        params: {},
+      },
+    });
+    const out = await logger.getOutput();
+    assert.ok(out.indexOf('ignoring github ref resolving. RESOLVE_GITREF_SERVICE is not set.') > 0);
+  });
+
+  it('Resolve resolves master ref correctly.', async () => {
+    const logger = Logger.getTestLogger({
+      level: 'debug',
+    });
+    const action = {
+      secrets: {
+        REPO_RAW_ROOT: 'https://raw.github.com/',
+        RESOLVE_GITREF_SERVICE,
+      },
+      logger,
+      request: {
+        params: {
+          owner: 'adobe',
+          repo: 'helix-cli',
+          ref: 'master',
+        },
+      },
+    };
+    await resolveRef({}, action);
+    assert.equal(action.request.params.ref, '565cb704628a094edde7e7f87d662b89559adcf0');
+  });
+
+  it('Resolve resolves master ref correctly using openwhisk.', async () => {
+    const logger = Logger.getTestLogger({
+      level: 'debug',
+    });
+    const action = {
+      secrets: {
+        REPO_RAW_ROOT: 'https://raw.github.com/',
+        RESOLVE_GITREF_SERVICE: SERVICE_ACTION,
+      },
+      logger,
+      request: {
+        params: {
+          owner: 'adobe',
+          repo: 'helix-cli',
+          ref: 'master',
+        },
+      },
+    };
+    try {
+      process.env.__OW_API_HOST = 'https://adobeioruntime.net';
+      process.env.__OW_API_KEY = WSK_TOKEN;
+      await resolveRef({}, action);
+    } finally {
+      delete process.env.__OW_API_HOST;
+      delete process.env.__OW_API_KEY;
+    }
+    assert.equal(action.request.params.ref, '565cb704628a094edde7e7f87d662b89559adcf0');
+  });
+
+  it('Resolve resolves missing ref as master correctly.', async () => {
+    const logger = Logger.getTestLogger({
+      level: 'debug',
+    });
+    const action = {
+      secrets: {
+        REPO_RAW_ROOT: 'https://raw.github.com/',
+        RESOLVE_GITREF_SERVICE,
+      },
+      logger,
+      request: {
+        params: {
+          owner: 'adobe',
+          repo: 'helix-cli',
+        },
+      },
+    };
+    await resolveRef({}, action);
+    const out = await logger.getOutput();
+    assert.ok(out.indexOf('Recoverable error: no ref given for helix-cli/adobe, falling back to master') > 0);
+    assert.equal(action.request.params.ref, '565cb704628a094edde7e7f87d662b89559adcf0');
+  });
+
+  it('Resolve ignores ref that looks like a SHA.', async () => {
+    const logger = Logger.getTestLogger({
+      level: 'debug',
+    });
+    const action = {
+      secrets: {
+        REPO_RAW_ROOT: 'https://raw.github.com/',
+        RESOLVE_GITREF_SERVICE,
+      },
+      logger,
+      request: {
+        params: {
+          owner: 'adobe',
+          repo: 'helix-cli',
+          ref: '9932fb0fa5853920d204d368af41c6efb3f7486c',
+        },
+      },
+    };
+    await resolveRef({}, action);
+    const out = await logger.getOutput();
+    assert.ok(out.indexOf('github-ref \'9932fb0fa5853920d204d368af41c6efb3f7486c\' looks like a SHA. Ignoring resolving.') > 0);
+    assert.equal(action.request.params.ref, '9932fb0fa5853920d204d368af41c6efb3f7486c');
+  });
+
+  it('Handles action error response.', async function test() {
+    const { server } = this.polly;
+    server
+      .get('https://adobeioruntime.net/api/v1/web/helix/helix-services/resolve-git-ref%40v1')
+      .intercept((_, res) => res.sendStatus(500));
+
+    const logger = Logger.getTestLogger({
+      level: 'debug',
+    });
+    const action = {
+      secrets: {
+        REPO_RAW_ROOT: 'https://raw.github.com/',
+        RESOLVE_GITREF_SERVICE,
+      },
+      logger,
+      request: {
+        params: {
+          owner: 'adobe',
+          repo: 'helix-cli',
+          ref: 'master',
+        },
+      },
+    };
+    await resolveRef({}, action);
+    const out = await logger.getOutput();
+    assert.ok(out.indexOf('unable to resolve github-ref of master: 500 - "Internal Server Error"') > 0);
+    assert.equal(action.request.params.ref, 'master');
+  });
+
+  it('Refues to invoke openwhisk outside environment.', async () => {
+    const logger = Logger.getTestLogger({
+      level: 'debug',
+    });
+    const action = {
+      secrets: {
+        REPO_RAW_ROOT: 'https://raw.github.com/',
+        RESOLVE_GITREF_SERVICE: SERVICE_ACTION,
+      },
+      logger,
+      request: {
+        params: {
+          owner: 'adobe',
+          repo: 'helix-cli',
+          ref: 'master',
+        },
+      },
+    };
+    await resolveRef({}, action);
+    const out = await logger.getOutput();
+    assert.ok(out.indexOf('unable to resolve github-ref of master: cannot invoke action outside openwhisk environment.') > 0);
+    assert.equal(action.request.params.ref, 'master');
+  });
+
+  it('Handles action status error response.', async function test() {
+    const { server } = this.polly;
+    server
+      .get('https://adobeioruntime.net/api/v1/web/helix/helix-services/resolve-git-ref%40v1')
+      .intercept((_, res) => {
+        res.send({
+          status: 'error',
+          statusMessage: 'unknown error',
+          statusCode: 500,
+        });
+      });
+
+    const logger = Logger.getTestLogger({
+      level: 'debug',
+    });
+    const action = {
+      secrets: {
+        REPO_RAW_ROOT: 'https://raw.github.com/',
+        RESOLVE_GITREF_SERVICE,
+      },
+      logger,
+      request: {
+        params: {
+          owner: 'adobe',
+          repo: 'helix-cli',
+          ref: 'master',
+        },
+      },
+    };
+    await resolveRef({}, action);
+    const out = await logger.getOutput();
+    assert.ok(out.indexOf('unable to resolve github-ref of master: unknown error') > 0);
+    assert.equal(action.request.params.ref, 'master');
+  });
+});


### PR DESCRIPTION
fixes #382

## Question
I currently set the the API endpoint in the secrets schema to the empty string.

```
    "RESOLVE_GITREF_SERVICE": {
      "type": "string",
      "description": "API endpoint to micro service that resolves github refs to commit SHAs.",
      "default": ""
    }
```

This has the advantage, that all action don't use the new lookup right away. so for it to work, we also need to set the action param during `hlx deploy`. This will be required anyways, because we want to execute the lookup action in the users namespace and not the helix one.



