### PR TITLE
feat(html pipe): Unwrap hero images

### DIFF
--- a/src/html/unwrap-sole-images.js
+++ b/src/html/unwrap-sole-images.js
@@ -24,13 +24,14 @@ function unwrap({ content }) {
   sections.forEach((section) => {
     map(section, (node, index, parent) => {
       if (node.type === 'paragraph' // If we have a paragraph
-          && parent.type === 'root' // … in a top section
+          && (parent.type === 'root' // … in the document root
+            || parent.type === 'section') // … or in a section
           && parent.meta.types.includes('has-only-image') // … that only has images
           && parent.meta.types.includes('nb-image-1')) { // … and actually only 1 of them
         // … then consider it a hero image, and unwrap from the paragraph
-        const position = content.mdast.children.indexOf(node);
-        const [img] = content.mdast.children[position].children;
-        content.mdast.children[position] = img;
+        const position = parent.children.indexOf(node);
+        const [img] = parent.children[position].children;
+        parent.children[position] = img;
       }
     });
   });

--- a/test/testHTMLFromMarkdown.js
+++ b/test/testHTMLFromMarkdown.js
@@ -361,7 +361,7 @@ describe('Testing Markdown conversion', () => {
     });
   });
 
-  it('Unwraps hero images', async () => {
+  it('Unwraps hero images in the document root', async () => {
     await assertMd(`
         ![Foo](/bar.png)
       `, `
@@ -371,7 +371,7 @@ describe('Testing Markdown conversion', () => {
     });
   });
 
-  it('Unwraps hero images', async () => {
+  it('Unwraps hero images in sections', async () => {
     await assertMd(`
         # Foo
 

--- a/test/testHTMLFromMarkdown.js
+++ b/test/testHTMLFromMarkdown.js
@@ -371,6 +371,26 @@ describe('Testing Markdown conversion', () => {
     });
   });
 
+  it('Unwraps hero images', async () => {
+    await assertMd(`
+        # Foo
+
+        ---
+
+        ![Bar](/baz.png)
+
+      `, `
+        <div class="hlx-section" data-hlx-types="has-heading nb-heading-1 has-only-heading">
+          <h1 id="foo">Foo</h1>
+        </div>
+        <div class="hlx-section" data-hlx-types="has-image nb-image-1 has-only-image">
+          <img src="/baz.png" alt="Bar"/>
+        </div>
+    `, {
+      SANITIZE_DOM: true,
+    });
+  });
+
   it('Leaves regular images inside paragraphs', async () => {
     await assertMd(`
         # Baz


### PR DESCRIPTION
Unwrap sole images in a single paragraph in a section so the hero image is not inside a paragraph tag
(follow-up of dbcf627 to support new sections)

fix #338