### PR TITLE
Expose VDOM Transformer in Action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@adobe/eslint-config-helix": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@adobe/eslint-config-helix/-/eslint-config-helix-1.0.0.tgz",
-      "integrity": "sha512-bJhywrb7EHgzSw5dPpAR+heNjN0Bw9d6GgHAcVE8lU7T2ma53BKt3BwCmIHdC8SmL8gPac6Jfbkfvb0tYHpoRA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@adobe/eslint-config-helix/-/eslint-config-helix-1.1.0.tgz",
+      "integrity": "sha512-wE/nYil2DLXFACl+Tt9JmXoqV1uA6/PROAwoFWdqifVbl8aLjeFDt/fzdyjcqRAreaOiRn2yjHTE1VNTFhiCPw==",
       "dev": true,
       "requires": {
         "eslint-config-airbnb-base": "^14.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/helix-pipeline",
-  "version": "5.0.0",
+  "version": "5.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@adobe/eslint-config-helix": "^1.0.0",
+    "@adobe/eslint-config-helix": "^1.1.0",
     "@adobe/jsonschema2md": "^3.1.2",
     "@pollyjs/adapter-fetch": "^2.6.2",
     "@pollyjs/adapter-node-http": "^2.6.2",

--- a/src/html/make-html.js
+++ b/src/html/make-html.js
@@ -9,13 +9,12 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-const VDOMTransformer = require('../utils/mdast-to-vdom');
 
-function html({ content, request }, { logger, secrets }) {
+function html({ content }, { logger, transformer }) {
   const { mdast } = content;
   logger.log('debug', `Turning Markdown into HTML from ${typeof mdast}`);
-  const extension = request && request.extension ? request.extension : 'html';
-  content.document = new VDOMTransformer(mdast, ({ extension, ...secrets }))
+  content.document = transformer
+    .withMdast(mdast)
     .getDocument();
 }
 

--- a/src/html/parse-markdown.js
+++ b/src/html/parse-markdown.js
@@ -12,13 +12,20 @@
 const unified = require('unified');
 const remark = require('remark-parse');
 const { setdefault } = require('ferrum');
+const VDOMTransformer = require('../utils/mdast-to-vdom');
 
-function parseMarkdown(context, { logger }) {
+function parseMarkdown(context, action) {
   const content = setdefault(context, 'content', {});
   const body = setdefault(content, 'body', '');
 
-  logger.debug(`Parsing markdown from request body starting with ${body.split('\n')[0]}`);
+  const request = setdefault(context, 'request', {});
+  const extension = setdefault(request, 'extension', 'html');
+
+  action.logger.debug(`Parsing markdown from request body starting with ${body.split('\n')[0]}`);
   content.mdast = unified().use(remark).parse(body);
+  // initialize transformer
+  action.transformer = new VDOMTransformer()
+    .withOptions({ extension, ...action.secrets });
 }
 
 module.exports = parseMarkdown;

--- a/src/schemas/action.schema.json
+++ b/src/schemas/action.schema.json
@@ -31,6 +31,10 @@
     },
     "secrets": {
       "$ref": "https://ns.adobe.com/helix/pipeline/secrets"
+    },
+    "transformer": {
+      "type": "object",
+      "description": "A VDOMTransformer instance"
     }
   }
 }

--- a/test/testHTMLOverrides.js
+++ b/test/testHTMLOverrides.js
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2018 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+const assert = require('assert');
+const { Logger } = require('@adobe/helix-shared');
+const { pipe } = require('../src/defaults/html.pipe.js');
+
+const logger = Logger.getTestLogger({
+  // tune this for debugging
+  level: 'info',
+});
+
+const params = {
+  path: '/hello.md',
+  __ow_method: 'get',
+  owner: 'trieloff',
+  __ow_headers: {
+    'X-Forwarded-Port': '443',
+    'X-CDN-Request-Id': '2a208a89-e071-44cf-aee9-220880da4c1e',
+    'Fastly-Client': '1',
+    'X-Forwarded-Host': 'runtime.adobe.io',
+    'Upgrade-Insecure-Requests': '1',
+    Host: 'controller-a',
+    Connection: 'close',
+    'Fastly-SSL': '1',
+    'X-Request-Id': 'RUss5tPdgOfw74a68aNc24FeTipGpVfW',
+    'X-Branch': 'master',
+    'Accept-Language': 'en-US, en;q=0.9, de;q=0.8',
+    'X-Forwarded-Proto': 'https',
+    'Fastly-Orig-Accept-Encoding': 'gzip',
+    'X-Varnish': '267021320',
+    DNT: '1',
+    'X-Forwarded-For':
+      '192.147.117.11, 157.52.92.27, 23.235.46.33, 10.64.221.107',
+    'X-Host': 'www.primordialsoup.life',
+    Accept:
+      'text/html, application/xhtml+xml, application/xml;q=0.9, image/webp, image/apng, */*;q=0.8',
+    'X-Real-IP': '10.64.221.107',
+    'X-Forwarded-Server': 'cache-lcy19249-LCY, cache-iad2127-IAD',
+    'Fastly-Client-IP': '192.147.117.11',
+    'Perf-Br-Req-In': '1529585370.116',
+    'X-Timer': 'S1529585370.068237,VS0,VS0',
+    'Fastly-FF':
+      'dc/x3e9z8KMmlHLQr8BEvVMmTcpl3y2YY5y6gjSJa3g=!LCY!cache-lcy19249-LCY, dc/x3e9z8KMmlHLQr8BEvVMmTcpl3y2YY5y6gjSJa3g=!LCY!cache-lcy19227-LCY, dc/x3e9z8KMmlHLQr8BEvVMmTcpl3y2YY5y6gjSJa3g=!IAD!cache-iad2127-IAD, dc/x3e9z8KMmlHLQr8BEvVMmTcpl3y2YY5y6gjSJa3g=!IAD!cache-iad2133-IAD',
+    'Accept-Encoding': 'gzip',
+    'User-Agent':
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36',
+  },
+  repo: 'soupdemo',
+  ref: 'master',
+  selector: 'md',
+};
+
+const secrets = {
+  REPO_RAW_ROOT: 'https://raw.githubusercontent.com/',
+};
+
+
+const crequest = {
+  extension: 'html',
+  url: '/test/test.html',
+};
+
+describe('Testing HTML Pipeline Overrides', () => {
+  it('html.pipe adds headers from meta and link tags', async () => {
+    const myfunc = (context) => {
+      context.response = {
+        body: `<html>
+<head>
+  <title>Hello World</title>
+</head>
+<body>
+  ${context.content.document.body.innerHTML}
+</body>
+</html>`,
+      };
+    };
+
+    myfunc.after = {
+      parse: (_, action) => {
+        // match all "emphasis" nodes
+        action.transformer.match('emphasis', (h, node, _, handlechild) => {
+          // create a new HTML tag <i class="its-not-semantic…">
+          const i = h(node, 'i', { className: 'its-not-semantic-html-but-i-like-it' });
+          // make sure all child nodes of the markdown node are processed
+          node.children.forEach((childnode) => handlechild(h, childnode, node, i));
+          // return the i HTML element
+          return i;
+        });
+      },
+    };
+
+    const result = await pipe(
+      myfunc,
+      {
+        request: crequest,
+        content: {
+          body: 'Hello _World_',
+        },
+      },
+      {
+        request: { params },
+        secrets,
+        logger,
+      },
+    );
+
+    assert.ok(result.response.body.match(/<i class="its-not-semantic-html-but-i-like-it">World<\/i>/));
+  });
+});

--- a/test/testMdastToVDOM.js
+++ b/test/testMdastToVDOM.js
@@ -44,7 +44,7 @@ describe('Test MDAST to VDOM Transformation', () => {
   it('Simple MDAST Conversion', () => {
     const mdast = fs.readJSONSync(path.resolve(__dirname, 'fixtures', 'simple.json'));
     assertTransformerYieldsDocument(
-      new VDOM(mdast, action.secrets),
+      new VDOM(mdast, action.secrets), // .withOptions(action.secrets),
       '<h1 id="hello-world">Hello World</h1>',
     );
   });


### PR DESCRIPTION
Fixes #325 

Manually creating the VDOM Transformer in `pre.js` was always dependent on making sure that all updates to `content.mdast` got intercepted. By exposing the transformer in `action.transformer`, it can be hooked into easily by adding a `exports.before.html` extension function that adds new `action.transformer.match()` calls.

The documentation has been updated to reflect the new usage pattern and references to the removed responsifier #380 have been removed.