### PR TITLE
feat(cache): increase cache timeouts and enable stale serving

### DIFF
--- a/src/html/shared-cache.js
+++ b/src/html/shared-cache.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-const { setdefault } = require('ferrum');
+const { setdefault, pairs, foldl } = require('ferrum');
 
 function uncached({ response }) {
   return !(response && response.headers && response.headers['Cache-Control']);
@@ -19,7 +19,16 @@ function uncached({ response }) {
 function cache(context) {
   const res = setdefault(context, 'response', {});
   const headers = setdefault(res, 'headers', {});
-  headers['Cache-Control'] = 's-maxage=604800';
+  const directives = {
+    's-maxage': 30 * 24 * 3600, // serve from cache (without revalidation) for 30 days
+    'stale-while-revalidate': 365 * 24 * 3600, // serve stale (while revalidating in background) for a year
+  };
+
+  headers['Cache-Control'] = foldl(
+    pairs(directives),
+    '',
+    (a, [key, value]) => `${a + (a ? ', ' : '') + key}=${value}`,
+  );
 }
 
 module.exports = { uncached, cache };

--- a/test/testHTML.js
+++ b/test/testHTML.js
@@ -562,7 +562,7 @@ ${context.content.document.body.innerHTML}`,
     const res = result.response;
     assert.equal(res.status, 201);
     assert.equal(res.headers['Content-Type'], 'text/html');
-    assert.equal(res.headers['Cache-Control'], 's-maxage=604800');
+    assert.equal(res.headers['Cache-Control'], 's-maxage=2592000, stale-while-revalidate=31536000');
     assert.equal(res.headers['Surrogate-Key'], 'yt+7rF5AO4Kmk0aF');
     assert.equal(res.body[0], '<');
     assert.ok(res.body.match(/<img/));
@@ -607,7 +607,7 @@ ${context.content.document.body.innerHTML}`,
     const res = result.response;
     assert.equal(res.status, 201);
     assert.equal(res.headers['Content-Type'], 'text/html');
-    assert.equal(res.headers['Cache-Control'], 's-maxage=604800');
+    assert.equal(res.headers['Cache-Control'], 's-maxage=2592000, stale-while-revalidate=31536000');
     assert.equal(res.headers['Surrogate-Key'], 'yt+7rF5AO4Kmk0aF');
     assert.equal(res.body[0], '<');
     assert.ok(res.body.match(/<img/));
@@ -652,7 +652,7 @@ ${context.content.document.body.innerHTML}`,
     const res = result.response;
     assert.equal(res.status, 201);
     assert.equal(res.headers['Content-Type'], 'text/html');
-    assert.equal(res.headers['Cache-Control'], 's-maxage=604800');
+    assert.equal(res.headers['Cache-Control'], 's-maxage=2592000, stale-while-revalidate=31536000');
     assert.equal(res.headers['Surrogate-Key'], '+XCHRiDHBAUBviSX');
     assert.equal(res.body[0], '<');
     assert.ok(res.body.match(/<img/));


### PR DESCRIPTION
increase the cache timeout from 7 days to 30 days and allow serving stale content (Fastly will revalidate in the background) for up to 365 days

See https://github.com/adobe/helix-home/issues/51 (other than outlined in the issue, I think it's better to apply the cache settings in the lower-level action rather than in the dispatch action)