### PR TITLE
Relax Frontmatter Parsing

### DIFF
--- a/src/html/parse-frontmatter.js
+++ b/src/html/parse-frontmatter.js
@@ -167,17 +167,17 @@ const findFrontmatter = (mdast, str) => {
     if (!fst.before) {
       return warn(null,
         'Found ambigous frontmatter fence: No empty line before the block! '
-          + 'Make sure your frontmatter blocks contain no empty lines '
+          + 'Make sure your mid-document YAML blocks contain no empty lines '
           + 'and your horizontal rules have an empty line before AND after them.');
     } else if (!last.after) {
       return warn(null,
         'Found ambigous frontmatter fence: No empty line after the block! '
-          + 'Make sure your frontmatter blocks contain no empty lines '
+          + 'Make sure your mid-document YAML blocks contain no empty lines '
           + 'and your horizontal rules have an empty line before AND after them.');
     } else if (src.match(re(`\\n${hspace}*\\n`)) && fst.idx > 0) {
       return warn(null,
         'Found ambigous frontmatter fence: Block contains empty line! '
-          + 'Make sure your frontmatter blocks contain no empty lines '
+          + 'Make sure your mid-document YAML blocks contain no empty lines '
           + 'and your horizontal rules have an empty line before AND after them.');
     }
 

--- a/src/html/parse-frontmatter.js
+++ b/src/html/parse-frontmatter.js
@@ -150,6 +150,7 @@ const findFrontmatter = (mdast, str) => {
   const toIgnore = (n) => !n || decentHead(n) || decentHr(n);
 
   const procwarnigns = map(([fst, last]) => {
+    console.log('procwarnings', fst, last);
     const src = str.slice(fst.offStart, last === null ? undefined : last.offEnd);
 
     const warn = (cause, prosa) => ({
@@ -173,7 +174,7 @@ const findFrontmatter = (mdast, str) => {
         'Found ambigous frontmatter fence: No empty line after the block! '
           + 'Make sure your frontmatter blocks contain no empty lines '
           + 'and your horizontal rules have an empty line before AND after them.');
-    } else if (src.match(re(`\\n${hspace}*\\n`))) {
+    } else if (src.match(re(`\\n${hspace}*\\n`)) && fst.idx > 0) {
       return warn(null,
         'Found ambigous frontmatter fence: Block contains empty line! '
           + 'Make sure your frontmatter blocks contain no empty lines '
@@ -285,7 +286,7 @@ const parseFrontmatter = ({ content = {} }) => {
       const cnt = block.end - block.start + 1;
       mdast.children.splice(block.start + off, cnt, dat);
       off += -cnt + 1; // cnt removed, 1 inserted
-    } else {
+    } else if (false) {
       const { warning, source, start } = block;
       const fst = mdast.children[start + off];
 

--- a/test/testGetMetadata.js
+++ b/test/testGetMetadata.js
@@ -26,7 +26,7 @@ const logger = Logger.getTestLogger({
 function callback(body) {
   const dat = { content: { body } };
   parse(dat, { logger });
-  parseFront(dat);
+  parseFront(dat, { logger });
   split(dat, { logger });
   getmetadata(dat, { logger });
   return dat.content.mdast;

--- a/test/testParseMarkdown.js
+++ b/test/testParseMarkdown.js
@@ -23,7 +23,7 @@ const logger = Logger.getTestLogger({
 function callback(body) {
   const dat = { content: { body } };
   parse(dat, { logger });
-  parseFront(dat);
+  parseFront(dat, { logger });
   return dat.content.mdast;
 }
 

--- a/test/testSplitSections.js
+++ b/test/testSplitSections.js
@@ -24,7 +24,7 @@ const logger = Logger.getTestLogger({
 function callback(body) {
   const data = { content: { body } };
   parse(data, { logger });
-  parseFront(data);
+  parseFront(data, { logger });
   split(data, { logger });
   return data.content.mdast.children;
 }


### PR DESCRIPTION
- no longer throw exceptions (we need to think about how to report this)
- do not require non-empty lines in the front matter block at the start of the document (same rules for other blocks)

fixes #441