### PR TITLE
Restrict embeds

### DIFF
--- a/src/html/find-embeds.js
+++ b/src/html/find-embeds.js
@@ -45,8 +45,8 @@ function iaEmbed({ type, children }, parent) {
     && children.length === 1
     && children[0].type === 'link'
     && (parent.type === 'root' || parent.type === 'section') // only direct children
-    && children[0].children[0] // needs to have a text node child
-    && children[0].children[0].value === children[0].url // no other link text
+    && children[0].children.length === 1
+    && (children[0].children[0].type === 'image' || children[0].children[0].value === children[0].url) // no other link text
     && URI.parse(children[0].url).reference === 'absolute') {
     return URI.parse(children[0].url);
   }

--- a/src/html/find-embeds.js
+++ b/src/html/find-embeds.js
@@ -40,10 +40,13 @@ function internalGatsbyEmbed(text, base, contentext, resourceext) {
  * Finds embeds that are single absolute links in a paragraph
  * @param {*} node An MDAST node
  */
-function iaEmbed({ type, children }) {
+function iaEmbed({ type, children }, parent) {
   if (type === 'paragraph'
     && children.length === 1
     && children[0].type === 'link'
+    && (parent.type === 'root' || parent.type === 'section') // only direct children
+    && children[0].children[0] // needs to have a text node child
+    && children[0].children[0].value === children[0].url // no other link text
     && URI.parse(children[0].url).reference === 'absolute') {
     return URI.parse(children[0].url);
   }
@@ -116,11 +119,11 @@ function find({ content: { mdast }, request: { extension, url } },
   { logger, secrets: { EMBED_WHITELIST, EMBED_SELECTOR }, request: { params: { path } } }) {
   const resourceext = `.${extension}`;
   const contentext = p.extname(path);
-  map(mdast, (node) => {
+  map(mdast, (node, _, parent) => {
     if (node.type === 'inlineCode' && gatsbyEmbed(node.value)) {
       embed(gatsbyEmbed(node.value), node, EMBED_WHITELIST, logger.debug);
-    } else if (node.type === 'paragraph' && iaEmbed(node)) {
-      embed(iaEmbed(node), node, EMBED_WHITELIST, logger.debug);
+    } else if (node.type === 'paragraph' && iaEmbed(node, parent)) {
+      embed(iaEmbed(node, parent), node, EMBED_WHITELIST, logger.debug);
     } else if (node.type === 'paragraph' && imgEmbed(node)) {
       embed(imgEmbed(node), node, EMBED_WHITELIST, logger.debug);
     } else if (node.type === 'inlineCode'

--- a/test/testEmbedHandler.js
+++ b/test/testEmbedHandler.js
@@ -130,6 +130,36 @@ describe('Integration Test with Embeds', () => {
     );
   });
 
+  it.only('html.pipe does not detect IA "embeds" in normal youtube links', async () => {
+    const result = await pipe(
+      (context) => {
+        context.response = { status: 201, body: context.content.document.body.innerHTML };
+      },
+      {
+        request: crequest,
+        content: {
+          body: `https://www.youtube.com/watch?balakaka
+
+[https://www.youtube.com/watch?balakaka](https://www.youtube.com/watch?balakaka)
+
+[this cool video](https://www.youtube.com/watch?balakaka)
+
+- [this cool video](https://www.youtube.com/watch?balakaka)
+`,
+        },
+      },
+      {
+        request: { params },
+        secrets,
+        logger,
+      },
+    );
+
+    assert.equal(result.response.status, 201);
+    assert.equal(result.response.headers['Content-Type'], 'text/html');
+    assert.equal(result.response.document.body.innerHTML.match(/<esi:include/g).length, 2);
+  });
+
   it('html.pipe processes embeds', async () => {
     const result = await pipe(
       (context) => {

--- a/test/testEmbedHandler.js
+++ b/test/testEmbedHandler.js
@@ -130,7 +130,7 @@ describe('Integration Test with Embeds', () => {
     );
   });
 
-  it.only('html.pipe does not detect IA "embeds" in normal youtube links', async () => {
+  it('html.pipe does not detect IA "embeds" in normal youtube links', async () => {
     const result = await pipe(
       (context) => {
         context.response = { status: 201, body: context.content.document.body.innerHTML };


### PR DESCRIPTION
This PR fixes #511 by making the detection of IA embeds a bit more restrictive
- only embeds in paragraphs directly below the root node are accepted (no more embeds in list items)
- only embeds where the link text equals the URL are accepted (no random single YouTube links turn into embeds anymore)