### PR TITLE
feat(html): rewrite image URL for Azure Blob store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/helix-pipeline",
-  "version": "6.1.8",
+  "version": "6.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/utils/image-handler.js
+++ b/src/utils/image-handler.js
@@ -18,7 +18,10 @@ function image() {
       const patchednode = {
         ...node,
       };
-      patchednode.url = `${node.url.replace(/^https:\/\/hlx\.blob\.core\.windows\.net\/external\//, '/hlx_')}.jpg`;
+      const [filename, fragment] = node.url.split('/').pop().split('#');
+      const fragmentextension = fragment ? fragment.split('.').pop() : undefined;
+      const extension = fragmentextension || 'jpg';
+      patchednode.url = `/hlx_${filename}.${extension}`;
       return fallback(h, patchednode);
     }
     return fallback(h, node);

--- a/src/utils/image-handler.js
+++ b/src/utils/image-handler.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+const fallback = require('mdast-util-to-hast/lib/handlers').image;
+
+function image() {
+  return function handler(h, node) {
+    // rewrite blob links to use Fastly
+    if (/^https:\/\/hlx\.blob\.core\.windows\.net\/external\//.test(node.url)) {
+      const patchednode = {
+        ...node,
+      };
+      patchednode.url = `${node.url.replace(/^https:\/\/hlx\.blob\.core\.windows\.net\/external\//, '/hlx_')}.jpg`;
+      return fallback(h, patchednode);
+    }
+    return fallback(h, node);
+  };
+}
+
+module.exports = image;

--- a/src/utils/mdast-to-vdom.js
+++ b/src/utils/mdast-to-vdom.js
@@ -20,6 +20,7 @@ const HeadingHandler = require('./heading-handler');
 const embed = require('./embed-handler');
 const link = require('./link-handler');
 const icon = require('./icon-handler');
+const image = require('./image-handler');
 const section = require('./section-handler');
 const types = require('../schemas/mdast.schema.json').properties.type.enum;
 
@@ -70,6 +71,7 @@ class VDOMTransformer {
     this.match('link', link(this._options));
     this.match('icon', icon(this._options));
     this.match('section', section(this._options));
+    this.match('image', image(this._options));
     this.match('html', (h, node) => {
       if (node.value.startsWith('<!--')) {
         return h.augment(node, {

--- a/test/fixtures/image-example.html
+++ b/test/fixtures/image-example.html
@@ -1,4 +1,6 @@
 <html><head></head><body><p>This is a normal image:</p>
 <p><img src="foo.png"></p>
 <p>This is a blob image:</p>
-<p><img src="/hlx_dccc13d784576fa3f0b3e06fb0ea705c49b8085.jpg"></p></body></html>
+<p><img src="/hlx_dccc13d784576fa3f0b3e06fb0ea705c49b8085.jpg"></p>
+<p>This is a blob image with type indication:</p>
+<p><img src="/hlx_dccc13d784576fa3f0b3e06fb0ea705c49b8085.png"></p></body></html>

--- a/test/fixtures/image-example.html
+++ b/test/fixtures/image-example.html
@@ -1,0 +1,4 @@
+<html><head></head><body><p>This is a normal image:</p>
+<p><img src="foo.png"></p>
+<p>This is a blob image:</p>
+<p><img src="/hlx_dccc13d784576fa3f0b3e06fb0ea705c49b8085.jpg"></p></body></html>

--- a/test/fixtures/image-example.md
+++ b/test/fixtures/image-example.md
@@ -5,3 +5,7 @@ This is a normal image:
 This is a blob image:
 
 ![](https://hlx.blob.core.windows.net/external/dccc13d784576fa3f0b3e06fb0ea705c49b8085)
+
+This is a blob image with type indication:
+
+![](https://hlx.blob.core.windows.net/external/dccc13d784576fa3f0b3e06fb0ea705c49b8085#image.png)

--- a/test/fixtures/image-example.md
+++ b/test/fixtures/image-example.md
@@ -1,0 +1,7 @@
+This is a normal image:
+
+![](foo.png)
+
+This is a blob image:
+
+![](https://hlx.blob.core.windows.net/external/dccc13d784576fa3f0b3e06fb0ea705c49b8085)

--- a/test/testMdastToVDOM.js
+++ b/test/testMdastToVDOM.js
@@ -19,6 +19,8 @@ const assert = require('assert');
 const { logging } = require('@adobe/helix-testutils');
 const { assertEquivalentNode } = require('@adobe/helix-shared').dom;
 const { JSDOM } = require('jsdom');
+const unified = require('unified');
+const parser = require('remark-parse');
 const VDOM = require('../').utils.vdom;
 const coerce = require('../src/utils/coerce-secrets');
 
@@ -210,6 +212,14 @@ describe('Test MDAST to VDOM Transformation', () => {
     const mdast = fs.readJSONSync(path.resolve(__dirname, 'fixtures', 'icon-example.json'));
     const actual = new VDOM(mdast, action.secrets).getDocument().documentElement;
     const expected = new JSDOM(fs.readFileSync(path.resolve(__dirname, 'fixtures', 'icon-example.html')).toString('utf-8')).window.document.documentElement;
+    assert.deepEqual(actual.outerHTML, expected.outerHTML);
+  });
+
+  it('Image handler replaces blobs with Fastly proxies', () => {
+    const markdown = fs.readFileSync(path.resolve(__dirname, 'fixtures', 'image-example.md'));
+    const mdast = unified().use(parser).parse(markdown);
+    const actual = new VDOM(mdast, action.secrets).getDocument().documentElement;
+    const expected = new JSDOM(fs.readFileSync(path.resolve(__dirname, 'fixtures', 'image-example.html')).toString('utf-8')).window.document.documentElement;
     assert.deepEqual(actual.outerHTML, expected.outerHTML);
   });
 });


### PR DESCRIPTION
When using the Azure Blob store, for instance through `helix-googledocs2md` or `helix-word2md`, image links point directly to the Azure Blob store. This change replaces these URLs in the HTML output with links to the `hlx_*.jpg`, i.e. Blob Proxy support, so that images can be resized and delivered from the same domain as the main content.

fixes https://github.com/adobe/helix-word2md/issues/128 fixes https://github.com/adobe/helix-googledocs2md/issues/133 closes https://github.com/adobe/helix-word2md/pull/129 requires https://github.com/adobe/helix-publish/pull/278 supports https://github.com/davidnuescheler/theblog/issues/43