### PR TITLE
fix(embed): fix external embed service URL construction

### DIFF
--- a/src/utils/embed-handler.js
+++ b/src/utils/embed-handler.js
@@ -20,7 +20,7 @@ function embed({ EMBED_SERVICE } = {}) {
     const { url } = node;
     const props = {
       // prepend the embed service for absolute URLs
-      src: (URI.parse(url).reference === 'absolute' ? EMBED_SERVICE : '') + url,
+      src: (URI.parse(url).reference === 'absolute' ? `${EMBED_SERVICE}/` : '') + url,
     };
     const retval = [h(node, 'esi:include', props)];
 

--- a/src/utils/embed-handler.js
+++ b/src/utils/embed-handler.js
@@ -18,9 +18,13 @@ const URI = require('uri-js');
 function embed({ EMBED_SERVICE } = {}) {
   return function handler(h, node, _, handlechild) {
     const { url } = node;
+    let src = url;
+    if (URI.parse(url).reference === 'absolute') {
+      src = URI.normalize([EMBED_SERVICE, url.slice(-1) === '/' ? '/' : '', url].join(''));
+    }
     const props = {
       // prepend the embed service for absolute URLs
-      src: (URI.parse(url).reference === 'absolute' ? `${EMBED_SERVICE}/` : '') + url,
+      src,
     };
     const retval = [h(node, 'esi:include', props)];
 

--- a/test/testEmbedHandler.js
+++ b/test/testEmbedHandler.js
@@ -62,7 +62,7 @@ const params = {
 const secrets = {
   REPO_RAW_ROOT: 'https://raw.githubusercontent.com/',
   EMBED_WHITELIST: '*.youtube.com',
-  EMBED_SERVICE: 'https://example-embed-service.com',
+  EMBED_SERVICE: 'https://example-embed-service.com/',
 };
 
 const logger = logging.createTestLogger({

--- a/test/testEmbedHandler.js
+++ b/test/testEmbedHandler.js
@@ -62,7 +62,7 @@ const params = {
 const secrets = {
   REPO_RAW_ROOT: 'https://raw.githubusercontent.com/',
   EMBED_WHITELIST: '*.youtube.com',
-  EMBED_SERVICE: 'https://example-embed-service.com/',
+  EMBED_SERVICE: 'https://example-embed-service.com',
 };
 
 const logger = logging.createTestLogger({
@@ -88,7 +88,7 @@ describe('Test Embed Handler', () => {
 
 
     embed(action.secrets)((_, tagname, parameters, children) => {
-      assert.equal(parameters.src, 'https://adobeioruntime.net/api/v1/web/helix/helix-services/embed@v1https://www.example.com/');
+      assert.equal(parameters.src, 'https://adobeioruntime.net/api/v1/web/helix/helix-services/embed@v1/https://www.example.com/');
       assert.equal(children, undefined);
       assert.equal(tagname, 'esi:include');
     }, node);


### PR DESCRIPTION
the embed service expects the to-be-embedded URL to be passed after a trailing slash. The code did
not add the trailing slash, making it impossible for Adobe I/O Runtime to find the correct action to
execute. This change adds the correct slash again.

fixes https://github.com/adobe/helix-embed/issues/145 fixes #559