### PR TITLE
feat(pipeline): add options to force http1 for tests

### DIFF
--- a/src/utils/Downloader.js
+++ b/src/utils/Downloader.js
@@ -27,7 +27,7 @@ class Downloader {
     if (!secrets || !secrets.HTTP_TIMEOUT) {
       logger.warn('No HTTP timeout set, risk of denial-of-service');
     }
-    if (options.forceHttp1) {
+    if (options.forceHttp1 || process.env.HELIX_PIPELINE_FORCE_HTTP1) {
       this._fetchContext = fetchAPI.context({
         httpProtocol: 'http1',
         httpsProtocols: ['http1'],


### PR DESCRIPTION
provides an extra way (via the `HELIX_PIPELINE_FORCE_HTTP1` process env) to force http1 for helix-fetch. this is especially useful for tests that want to use pollyjs/nock but don't have a direct access to the pipeline action.

**Note**: After this is fixed, we need to update some of the `helix-cli` tests (eg: `testUpCmd.js`) to set the process env. for example:

```patch
diff --git a/test/testUpCmd.js b/test/testUpCmd.js
index 0c3bafe..ed565db 100644
--- a/test/testUpCmd.js
+++ b/test/testUpCmd.js
@@ -60,6 +60,7 @@ describe('Integration test for up command', function suite() {
   });

   beforeEach(async function beforeEach() {
+    process.env.HELIX_PIPELINE_FORCE_HTTP1 = true;
     this.polly.server.any()
       .filter((req) => req.headers.host.startsWith('localhost') || req.headers.host.startsWith('127.0.0.1'))
       .passthrough();
@@ -75,6 +76,7 @@ describe('Integration test for up command', function suite() {
   });

   afterEach(async () => {
+    delete process.env.HELIX_PIPELINE_FORCE_HTTP1;
     await fse.remove(testRoot);
   });
```