### PR TITLE
create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Description**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+
+- what's your Markdown document?
+- what's your template function?
+
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+- what kind of HTML do you want to see
+
+**Actual behavior**
+If applicable, add screenshots to help explain your problem.
+
+- what's the output you are seeing?
+- are there error messages?
+
+**Version:**
+run: `$ hlx --version`
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/discussion.md
+++ b/.github/ISSUE_TEMPLATE/discussion.md
@@ -1,0 +1,17 @@
+---
+name: Discussion
+about: Start a new discussion
+title: ''
+labels: question
+assignees: ''
+
+---
+
+## Overview
+whats' this discussion about?
+
+## Details
+more details
+
+## Proposed Actions
+and now?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
For some reason, helix-pipeline has been missing these. I've taken the liberty to rephrase the bug report template a bit.