### PR TITLE
feat(images): do not assume domain root is accessible, use `blob.hlx` URLs

### DIFF
--- a/docs/action-properties-secrets.md
+++ b/docs/action-properties-secrets.md
@@ -14,7 +14,7 @@ Secrets passed into the pipeline such as API Keys or configuration settings.
 
 `object` ([Secrets](action-properties-secrets.md))
 
-# Secrets Properties
+# secrets Properties
 
 | Property                                          | Type      | Required | Nullable       | Defined by                                                                                                                               |
 | :------------------------------------------------ | :-------- | :------- | :------------- | :--------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/content-properties-mdast.md
+++ b/docs/content-properties-mdast.md
@@ -14,7 +14,7 @@ A node in the Markdown AST
 
 `object` ([MDAST](content-properties-mdast.md))
 
-# MDAST Properties
+# mdast Properties
 
 | Property                        | Type          | Required | Nullable       | Defined by                                                                                                                      |
 | :------------------------------ | :------------ | :------- | :------------- | :------------------------------------------------------------------------------------------------------------------------------ |

--- a/docs/context-properties-request.md
+++ b/docs/context-properties-request.md
@@ -14,7 +14,7 @@ The HTTP Request
 
 `object` ([Request](context-properties-request.md))
 
-# Request Properties
+# request Properties
 
 | Property                    | Type          | Required | Nullable       | Defined by                                                                                                         |
 | :-------------------------- | :------------ | :------- | :------------- | :----------------------------------------------------------------------------------------------------------------- |

--- a/docs/context-properties-response.md
+++ b/docs/context-properties-response.md
@@ -14,7 +14,7 @@ The HTTP response object
 
 `object` ([Response](context-properties-response.md))
 
-# Response Properties
+# response Properties
 
 | Property              | Type          | Required | Nullable       | Defined by                                                                                                      |
 | :-------------------- | :------------ | :------- | :------------- | :-------------------------------------------------------------------------------------------------------------- |

--- a/docs/mdast-properties-data.md
+++ b/docs/mdast-properties-data.md
@@ -14,7 +14,7 @@ data is guaranteed to never be specified by unist or specifications implementing
 
 `object` ([Details](mdast-properties-data.md))
 
-# undefined Properties
+# data Properties
 
 | Property              | Type | Required | Nullable    | Defined by |
 | :-------------------- | :--- | :------- | :---------- | :--------- |

--- a/docs/meta-definitions-meta.md
+++ b/docs/meta-definitions-meta.md
@@ -14,7 +14,7 @@ https://ns.adobe.com/helix/pipeline/section#/definitions/section/properties/meta
 
 `object` ([Details](meta-definitions-meta.md))
 
-# undefined Properties
+# meta Properties
 
 | Property            | Type     | Required | Nullable       | Defined by                                                                                                                          |
 | :------------------ | :------- | :------- | :------------- | :---------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/position-properties-text-coordinates.md
+++ b/docs/position-properties-text-coordinates.md
@@ -14,7 +14,7 @@ A position in a text document
 
 `object` ([Text Coordinates](position-properties-text-coordinates.md))
 
-# Text Coordinates Properties
+# start Properties
 
 | Property          | Type     | Required | Nullable       | Defined by                                                                                                                        |
 | :---------------- | :------- | :------- | :------------- | :-------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/rawrequest-definitions-rawrequest-properties-headers.md
+++ b/docs/rawrequest-definitions-rawrequest-properties-headers.md
@@ -14,7 +14,7 @@ The headers of the request made to OpenWhisk (or Simulator)
 
 `object` ([Details](rawrequest-definitions-rawrequest-properties-headers.md))
 
-# undefined Properties
+# headers Properties
 
 | Property                                                | Type     | Required | Nullable       | Defined by                                                                                                                                                                                                                                   |
 | :------------------------------------------------------ | :------- | :------- | :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/rawrequest-definitions-rawrequest-properties-params.md
+++ b/docs/rawrequest-definitions-rawrequest-properties-params.md
@@ -14,7 +14,7 @@ Parameters used to invoke the OpenWhisk action. These are either URL parameters 
 
 `object` ([Details](rawrequest-definitions-rawrequest-properties-params.md))
 
-# undefined Properties
+# params Properties
 
 | Property                      | Type     | Required | Nullable       | Defined by                                                                                                                                                                                                       |
 | :---------------------------- | :------- | :------- | :------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/rawrequest-definitions-rawrequest.md
+++ b/docs/rawrequest-definitions-rawrequest.md
@@ -14,7 +14,7 @@ https://ns.adobe.com/helix/pipeline/rawrequest#/allOf/0
 
 unknown
 
-# undefined Properties
+# 0 Properties
 
 | Property            | Type     | Required | Nullable       | Defined by                                                                                                                                                         |
 | :------------------ | :------- | :------- | :------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/request-properties-headers.md
+++ b/docs/request-properties-headers.md
@@ -14,7 +14,7 @@ The HTTP headers of the request. Note: all header names will be lower-case.
 
 unknown
 
-# undefined Properties
+# headers Properties
 
 | Property              | Type     | Required | Nullable       | Defined by                                                                                                                                           |
 | :-------------------- | :------- | :------- | :------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/request-properties-params.md
+++ b/docs/request-properties-params.md
@@ -14,7 +14,7 @@ The passed through (and filtered) URL parameters of the request.
 
 `object` ([Details](request-properties-params.md))
 
-# undefined Properties
+# params Properties
 
 | Property              | Type   | Required | Nullable       | Defined by                                                                                                                                         |
 | :-------------------- | :----- | :------- | :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/response-properties-headers.md
+++ b/docs/response-properties-headers.md
@@ -14,7 +14,7 @@ The HTTP headers of the response
 
 unknown
 
-# undefined Properties
+# headers Properties
 
 | Property              | Type     | Required | Nullable       | Defined by                                                                                                                                              |
 | :-------------------- | :------- | :------- | :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/docs/section-definitions-section-properties-position.md
+++ b/docs/section-definitions-section-properties-position.md
@@ -14,7 +14,7 @@ Marks the position of an AST node in the original text flow
 
 `object` ([Position](section-definitions-section-properties-position.md))
 
-# Position Properties
+# position Properties
 
 | Property          | Type     | Required | Nullable       | Defined by                                                                                                                  |
 | :---------------- | :------- | :------- | :------------- | :-------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/section-definitions-section.md
+++ b/docs/section-definitions-section.md
@@ -14,7 +14,7 @@ https://ns.adobe.com/helix/pipeline/section#/definitions/section
 
 unknown
 
-# undefined Properties
+# section Properties
 
 | Property              | Type          | Required | Nullable       | Defined by                                                                                                                                            |
 | :-------------------- | :------------ | :------- | :------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/html/rewrite-blob-images.js
+++ b/src/html/rewrite-blob-images.js
@@ -12,7 +12,7 @@
 const visit = require('unist-util-visit');
 
 /**
- * Rewrite blob store image URLs to /hlx_* URLs
+ * Rewrite blob store image URLs to /blob.hlx/* URLs
  *
  * @param {object} request The content request
  */
@@ -26,7 +26,7 @@ function rewrite({ content }) {
       const { pathname, hash } = new URL(node.url);
       const filename = pathname.split('/').pop();
       const extension = hash.includes('.') ? hash.split('.').pop() : 'jpg';
-      node.url = `/hlx_${filename}.${extension}`;
+      node.url = `./blob.hlx/${filename}.${extension}`;
     }
   });
 }

--- a/test/fixtures/image-rewritten-example.json
+++ b/test/fixtures/image-rewritten-example.json
@@ -36,7 +36,7 @@
           "alt": null,
           "title": null,
           "type": "image",
-          "url": "/hlx_dccc13d784576fa3f0b3e06fb0ea705c49b8085.jpg"
+          "url": "./blob.hlx/dccc13d784576fa3f0b3e06fb0ea705c49b8085.jpg"
         }
       ],
       "type": "paragraph"
@@ -56,7 +56,7 @@
           "alt": null,
           "title": null,
           "type": "image",
-          "url": "/hlx_dccc13d784576fa3f0b3e06fb0ea705c49b8085.png"
+          "url": "./blob.hlx/dccc13d784576fa3f0b3e06fb0ea705c49b8085.png"
         }
       ],
       "type": "paragraph"


### PR DESCRIPTION

This is changing the default blob URL from `/hlx_…` to `./blob.hlx/…` so that it can work at any level

BREAKING CHANGE: Blob image URL changes from absolute to relative, requires https://github.com/adobe/helix-publish/pull/718