### PR TITLE
feat(content): add support for github pages

### DIFF
--- a/src/utils/Downloader.js
+++ b/src/utils/Downloader.js
@@ -61,6 +61,13 @@ class Downloader {
   }
 
   computeGithubURI(owner, repo, ref, path) {
+    if (ref === 'gh-pages') {
+      const url = new URL(`https://${owner}.github.io`);
+      // remove double slashes
+      url.pathname = `/${repo}/${path}`.replace(/\/+/g, '/');
+      return url.href;
+    }
+
     const rootURI = URI.parse(this.githubRootPath);
     const rootPath = rootURI.path;
     // remove double slashes

--- a/test/testDownloader.js
+++ b/test/testDownloader.js
@@ -122,6 +122,19 @@ describe('Test URI parsing and construction', () => {
       'https://raw.githubusercontent.com/adobe/xdm/tags/release_1/README.md',
     );
   });
+
+  it('computeGithubURI generates github pages uri', () => {
+    assert.equal(
+      compute(
+        'https://raw.githubusercontent.com',
+        'adobe',
+        '/xdm/',
+        'gh-pages',
+        '/README.md',
+      ),
+      'https://adobe.github.io/xdm/README.md',
+    );
+  });
 });
 
 describe('Test input validation', () => {


### PR DESCRIPTION
adds support for gh-pages using the branch name to select a different github _root_.
see https://github.com/adobe/helix-home/issues/191