### PR TITLE
fix: respect image hashes with dimensions

### DIFF
--- a/src/html/rewrite-blob-images.js
+++ b/src/html/rewrite-blob-images.js
@@ -19,7 +19,9 @@ function images(document) {
     if (/^https:\/\/hlx\.blob\.core\.windows\.net\/external\//.test(img.src)) {
       const { pathname, hash } = new URL(img.src);
       const filename = pathname.split('/').pop();
-      const extension = hash.includes('.') ? hash.split('.').pop() : 'jpg';
+
+      // remove width/height from hash, since helix-pages doesn't support it yet
+      const extension = hash.split('?').shift().split('.').pop() || 'jpg';
       img.src = `./media_${filename}.${extension}`;
     }
   });

--- a/test/fixtures/image-example.json
+++ b/test/fixtures/image-example.json
@@ -60,6 +60,17 @@
         }
       ],
       "type": "paragraph"
+    },
+    {
+      "children": [
+        {
+          "alt": null,
+          "title": null,
+          "type": "image",
+          "url": "https://hlx.blob.core.windows.net/external/dccc13d784576fa3f0b3e06fb0ea705c49b8085#image.gif?width=100&height=100"
+        }
+      ],
+      "type": "paragraph"
     }
   ]
 }

--- a/test/fixtures/image-rewritten-example.html
+++ b/test/fixtures/image-rewritten-example.html
@@ -3,4 +3,5 @@
 <p>This is a blob image:</p>
 <p><img src="./media_dccc13d784576fa3f0b3e06fb0ea705c49b8085.jpg"></p>
 <p>This is a blob image with type indication:</p>
-<p><img src="./media_dccc13d784576fa3f0b3e06fb0ea705c49b8085.png"></p></body>
+<p><img src="./media_dccc13d784576fa3f0b3e06fb0ea705c49b8085.png"></p>
+<p><img src="./media_dccc13d784576fa3f0b3e06fb0ea705c49b8085.gif"></p></body>

--- a/test/testRewriteBlobImages.js
+++ b/test/testRewriteBlobImages.js
@@ -29,7 +29,7 @@ describe('Test Blob Image Rewriting', () => {
       content: { document },
     };
     rewriteBlobImages(context);
-    assert.equal(context.content.document.documentElement.innerHTML.trim(), expected.trim());
+    assert.strictEqual(context.content.document.documentElement.innerHTML.trim(), expected.trim());
   });
 
   it('Does not throw error if document is missing', () => {


### PR DESCRIPTION
with the inclusion of the image dimensions, we should remove them when rewriting the image urls to the media-urls, until the helix-pages picture handling is adjusted accordingly.